### PR TITLE
Fix Tab Error in geometry file

### DIFF
--- a/geometry/shipLHC_geom_config.py
+++ b/geometry/shipLHC_geom_config.py
@@ -5,48 +5,48 @@ from ShipGeoConfig import AttrDict, ConfigRegistry
 
 with ConfigRegistry.register_config("basic") as c:
 # cave parameters
-	c.cave = AttrDict(z=0*u.cm)
+        c.cave = AttrDict(z=0*u.cm)
 
-	c.EmulsionDet = AttrDict(z=0*u.cm)
-	c.EmulsionDet.zC = 0*u.m
+        c.EmulsionDet = AttrDict(z=0*u.cm)
+        c.EmulsionDet.zC = 0*u.m
         c.EmulsionDet.wall= 5
-	c.EmulsionDet.target = 1  #number of neutrino target volumes
-	c.EmulsionDet.n_plates = 56
-	c.EmulsionDet.EmTh = 0.0070 * u.cm
-	c.EmulsionDet.EmX = 41.0 * u.cm
-	c.EmulsionDet.EmY = 41.0 * u.cm
-	c.EmulsionDet.PBTh = 0.0175 * u.cm
-	c.EmulsionDet.PassiveTh = 0.1 * u.cm
-	c.EmulsionDet.EPlW = 2* c.EmulsionDet.EmTh + c.EmulsionDet.PBTh
-	c.EmulsionDet.AllPW = c.EmulsionDet.PassiveTh + c.EmulsionDet.EPlW
-	c.EmulsionDet.BrX = c.EmulsionDet.EmX
-	c.EmulsionDet.BrY = c.EmulsionDet.EmY
-	c.EmulsionDet.BrPackZ = 0.*u.cm
-	c.EmulsionDet.BrPackX = 0.*u.cm
-	c.EmulsionDet.BrPackY = 0.*u.cm
-	c.EmulsionDet.BrZ = c.EmulsionDet.n_plates * c.EmulsionDet.AllPW + c.EmulsionDet.EPlW + c.EmulsionDet.BrPackZ
-	c.EmulsionDet.xdim = c.EmulsionDet.EmX
-	c.EmulsionDet.ydim = c.EmulsionDet.EmY
-	c.EmulsionDet.WallXDim = c.EmulsionDet.EmX
-	c.EmulsionDet.WallYDim = c.EmulsionDet.EmY
-	c.EmulsionDet.WallZDim = c.EmulsionDet.BrZ
-	c.EmulsionDet.TTz = 3.0*u.cm
+        c.EmulsionDet.target = 1  #number of neutrino target volumes
+        c.EmulsionDet.n_plates = 56
+        c.EmulsionDet.EmTh = 0.0070 * u.cm
+        c.EmulsionDet.EmX = 41.0 * u.cm
+        c.EmulsionDet.EmY = 41.0 * u.cm
+        c.EmulsionDet.PBTh = 0.0175 * u.cm
+        c.EmulsionDet.PassiveTh = 0.1 * u.cm
+        c.EmulsionDet.EPlW = 2* c.EmulsionDet.EmTh + c.EmulsionDet.PBTh
+        c.EmulsionDet.AllPW = c.EmulsionDet.PassiveTh + c.EmulsionDet.EPlW
+        c.EmulsionDet.BrX = c.EmulsionDet.EmX
+        c.EmulsionDet.BrY = c.EmulsionDet.EmY
+        c.EmulsionDet.BrPackZ = 0.*u.cm
+        c.EmulsionDet.BrPackX = 0.*u.cm
+        c.EmulsionDet.BrPackY = 0.*u.cm
+        c.EmulsionDet.BrZ = c.EmulsionDet.n_plates * c.EmulsionDet.AllPW + c.EmulsionDet.EPlW + c.EmulsionDet.BrPackZ
+        c.EmulsionDet.xdim = c.EmulsionDet.EmX
+        c.EmulsionDet.ydim = c.EmulsionDet.EmY
+        c.EmulsionDet.WallXDim = c.EmulsionDet.EmX
+        c.EmulsionDet.WallYDim = c.EmulsionDet.EmY
+        c.EmulsionDet.WallZDim = c.EmulsionDet.BrZ
+        c.EmulsionDet.TTz = 3.0*u.cm
         c.EmulsionDet.zdim = c.EmulsionDet.wall* c.EmulsionDet.WallZDim + (c.EmulsionDet.wall+1)*c.EmulsionDet.TTz
-	c.EmulsionDet.ShiftX = 8.0*u.cm
-	c.EmulsionDet.ShiftY = 15.5*u.cm
+        c.EmulsionDet.ShiftX = 8.0*u.cm
+        c.EmulsionDet.ShiftY = 15.5*u.cm
 
-	c.Scifi = AttrDict(z=0*u.cm)
-	c.Scifi.xdim = c.EmulsionDet.xdim
-	c.Scifi.ydim = c.EmulsionDet.ydim
-	c.Scifi.zdim = c.EmulsionDet.TTz
-	c.Scifi.DZ = c.EmulsionDet.BrZ
-	c.Scifi.nplanes = c.EmulsionDet.wall+1
+        c.Scifi = AttrDict(z=0*u.cm)
+        c.Scifi.xdim = c.EmulsionDet.xdim
+        c.Scifi.ydim = c.EmulsionDet.ydim
+        c.Scifi.zdim = c.EmulsionDet.TTz
+        c.Scifi.DZ = c.EmulsionDet.BrZ
+        c.Scifi.nplanes = c.EmulsionDet.wall+1
 
-	c.MuFilter = AttrDict(z=0*u.cm)
-	c.MuFilter.ShiftDY = 2.0*u.cm
-	c.MuFilter.ShiftDYTot = 6.0*u.cm
-	#c.MuFilter.X = c.EmulsionDet.xdim + 20*u.cm
-	c.MuFilter.X = 62.0*u.cm
+        c.MuFilter = AttrDict(z=0*u.cm)
+        c.MuFilter.ShiftDY = 2.0*u.cm
+        c.MuFilter.ShiftDYTot = 6.0*u.cm
+        #c.MuFilter.X = c.EmulsionDet.xdim + 20*u.cm
+        c.MuFilter.X = 62.0*u.cm
         #c.MuFilter.Y = c.EmulsionDet.ydim + 20*u.cm+10.0*u.cm
         c.MuFilter.Y = 60.5*u.cm+c.MuFilter.ShiftDYTot
         c.MuFilter.FeX = c.MuFilter.X
@@ -61,7 +61,7 @@ with ConfigRegistry.register_config("basic") as c:
         c.MuFilter.DownstreamDetY = c.MuFilter.FeY
         c.MuFilter.DownstreamDetZ = 4*u.cm
         c.MuFilter.NDownstreamPlanes=3
-        
+
         #upstream bars configuration
         c.MuFilter.NUpstreamBars = 11
         c.MuFilter.OverlapUpstreamBars = 0.5*u.cm
@@ -81,7 +81,7 @@ with ConfigRegistry.register_config("basic") as c:
         c.MuFilter.DownstreamBarZ_ver = 1*u.cm
 
         #total z thickness and position
-	c.MuFilter.Z = c.MuFilter.NUpstreamPlanes*(c.MuFilter.FeZ+c.MuFilter.UpstreamDetZ) + c.MuFilter.NDownstreamPlanes*(c.MuFilter.FeZ+c.MuFilter.DownstreamDetZ) 
-	c.MuFilter.Zcenter = c.EmulsionDet.zC+c.EmulsionDet.zdim/2+c.MuFilter.Z/2
-	c.MuFilter.ShiftX = c.EmulsionDet.ShiftX+c.EmulsionDet.xdim/2
-	c.MuFilter.ShiftY = 3.55*u.cm #since y size increased of 0.5, we need to increase this shift from 3.3 to 3.55
+        c.MuFilter.Z = c.MuFilter.NUpstreamPlanes*(c.MuFilter.FeZ+c.MuFilter.UpstreamDetZ) + c.MuFilter.NDownstreamPlanes*(c.MuFilter.FeZ+c.MuFilter.DownstreamDetZ) 
+        c.MuFilter.Zcenter = c.EmulsionDet.zC+c.EmulsionDet.zdim/2+c.MuFilter.Z/2
+        c.MuFilter.ShiftX = c.EmulsionDet.ShiftX+c.EmulsionDet.xdim/2
+        c.MuFilter.ShiftY = 3.55*u.cm #since y size increased of 0.5, we need to increase this shift from 3.3 to 3.55


### PR DESCRIPTION
Dear all,

my local installation refused to launch a simulation with the following error.

Traceback (most recent call last):
  File "/home/utente/SHIPBUILD/FairShip/macro/run_simScript.py", line 214, in <module>
    ship_geo = ConfigRegistry.loadpy("$FAIRSHIP/geometry/shipLHC_geom_config.py")
  File "/home/utente/SHIPBUILD/sw/ubuntu1604_x86-64/FairShip/master-1/python/ShipGeoConfig.py", line 50, in loadpy
    return ConfigRegistry.loadpys(fh.read(), **kwargs)
  File "/home/utente/SHIPBUILD/sw/ubuntu1604_x86-64/FairShip/master-1/python/ShipGeoConfig.py", line 55, in loadpys
    exec(string_unixlf, kwargs)
  File "<string>", line 12
    c.EmulsionDet.wall= 5
                        ^
TabError: inconsistent use of tabs and spaces in indentation

Strangely, lxplus does not launch the same error. However, checking the whitespaces with Emacs I have confirmed the different indentations, so I manually changed all to Emacs tabs. Afterwards, I was able to launch the simulation without errors.

Best regards,
Antonio