### PR TITLE
Replacing Muon Filter volume with Assembly

### DIFF
--- a/shipLHC/MuFilter.cxx
+++ b/shipLHC/MuFilter.cxx
@@ -225,8 +225,7 @@ void MuFilter::ConstructGeometry()
 	TGeoMedium *Scint =gGeoManager->GetMedium("polyvinyltoluene");
 
 	//Definition of the box containing Fe Blocks + Timing Detector planes 
-	TGeoBBox *MuFilterBox = new TGeoBBox("MuFilterBox",fMuFilterX/2,fMuFilterY/2,fMuFilterZ/2);
-	TGeoVolume *volMuFilter = new TGeoVolume("volMuFilter",MuFilterBox,air);
+	TGeoVolumeAssembly *volMuFilter = new TGeoVolumeAssembly("volMuFilter");
 
 	//Iron blocks volume definition
 	TGeoBBox *FeBlockBox = new TGeoBBox("FeBlockBox",fFeBlockX/2, fFeBlockY/2, fFeBlockZ/2);


### PR DESCRIPTION
Following @ThomasRuf's advice on #12, 
this solves the overlap between the floor volume and the muon filter mother volume