### PR TITLE
Save hits even if Volume ID is the same of Detector ID

### DIFF
--- a/shipLHC/EmulsionDet.cxx
+++ b/shipLHC/EmulsionDet.cxx
@@ -333,13 +333,7 @@ Bool_t  EmulsionDet::ProcessHits(FairVolume* vol)
         gMC->IsTrackStop()       ||
         gMC->IsTrackDisappeared()   ) {
         fTrackID  = gMC->GetStack()->GetCurrentTrackNumber();
-        fVolumeID = vol->getMCid();
-	Int_t detID=0;
-	gMC->CurrentVolID(detID);
-
-	if (fVolumeID == detID) {
-	  return kTRUE; }
-	fVolumeID = detID;
+	gMC->CurrentVolID(fVolumeID);
 
 	gGeoManager->PrintOverlaps();		
 	

--- a/shipLHC/MuFilter.cxx
+++ b/shipLHC/MuFilter.cxx
@@ -346,12 +346,7 @@ Bool_t  MuFilter::ProcessHits(FairVolume* vol)
 			gMC->IsTrackDisappeared()   ) {
 		fTrackID  = gMC->GetStack()->GetCurrentTrackNumber();
 		fVolumeID = vol->getMCid();
-		Int_t detID=0;
-		gMC->CurrentVolID(detID);
-
-		if (fVolumeID == detID) {
-			return kTRUE; }
-		fVolumeID = detID;
+		gMC->CurrentVolID(fVolumeID);
 
 		gGeoManager->PrintOverlaps();
 

--- a/shipLHC/Scifi.cxx
+++ b/shipLHC/Scifi.cxx
@@ -162,16 +162,9 @@ Bool_t  Scifi::ProcessHits(FairVolume* vol)
         if (fELoss == 0. ) { return kFALSE; }
         TParticle* p=gMC->GetStack()->GetCurrentTrack();
         Int_t pdgCode = p->GetPdgCode();
+	gMC->CurrentVolID(fVolumeID);
 
-	Int_t detID=0;
-	gMC->CurrentVolID(detID);
-
-
-if (fVolumeID == detID) {
-	  return kTRUE; }
-	fVolumeID = detID;
-
-  TLorentzVector Pos; 
+	TLorentzVector Pos; 
         gMC->TrackPosition(Pos); 
         Double_t xmean = (fPos.X()+Pos.X())/2. ;      
         Double_t ymean = (fPos.Y()+Pos.Y())/2. ;      


### PR DESCRIPTION
Dear all,

Thomas noticed me of an issue already fixed in the FairShip nutaudet pull request:

https://github.com/ShipSoft/FairShip/pull/105

Basically, there is a check in ProcessHits: when hits are from the same detector ID as the MonteCarlo volume ID, they are not stored without any warning or known reason.

This removes this check, allowing to store all detector IDs.

Best regards,
Antonio