### PR TITLE
WIP: Updating Muon Filter position and structure of bars

### DIFF
--- a/geometry/shipLHC_geom_config.py
+++ b/geometry/shipLHC_geom_config.py
@@ -78,7 +78,7 @@ with ConfigRegistry.register_config("basic") as c:
         c.MuFilter.DownstreamBarY = c.MuFilter.DownstreamDetY/c.MuFilter.NDownstreamBars #computed for staggering
         c.MuFilter.DownstreamBarZ = 1*u.cm
 
-        c.MuFilter.DownstreamBarX_ver = c.MuFilter.DownstreamDetX/c.MuFilter.NDownstreamBars
+        c.MuFilter.DownstreamBarX_ver = c.MuFilter.DownstreamDetY/c.MuFilter.NDownstreamBars #the vertical bars cover a region only 60 x 60 cm2
         c.MuFilter.DownstreamBarY_ver = c.MuFilter.DownstreamDetY
         c.MuFilter.DownstreamBarZ_ver = 1*u.cm
 

--- a/geometry/shipLHC_geom_config.py
+++ b/geometry/shipLHC_geom_config.py
@@ -49,45 +49,44 @@ with ConfigRegistry.register_config("basic") as c:
         c.Scifi.nplanes = c.EmulsionDet.wall+1
 
         c.MuFilter = AttrDict(z=0*u.cm)
-        c.MuFilter.ShiftDY = 2.0*u.cm
-        c.MuFilter.ShiftDYTot = 6.0*u.cm
         #c.MuFilter.X = c.EmulsionDet.xdim + 20*u.cm
-        c.MuFilter.X = 62.0*u.cm
+        c.MuFilter.X = 80.0*u.cm
         #c.MuFilter.Y = c.EmulsionDet.ydim + 20*u.cm+10.0*u.cm
-        c.MuFilter.Y = 60.5*u.cm+c.MuFilter.ShiftDYTot
+        c.MuFilter.Y = 60.0*u.cm
         c.MuFilter.FeX = c.MuFilter.X
         #c.MuFilter.FeY = c.EmulsionDet.ydim + 20*u.cm
-        c.MuFilter.FeY = c.MuFilter.Y - c.MuFilter.ShiftDYTot
+        c.MuFilter.FeY = c.MuFilter.Y
         c.MuFilter.FeZ = 20*u.cm
         c.MuFilter.UpstreamDetX = c.MuFilter.X
         c.MuFilter.UpstreamDetY = c.MuFilter.FeY
-        c.MuFilter.UpstreamDetZ = 2*u.cm
+        c.MuFilter.UpstreamDetZ = 2.6*u.cm
         c.MuFilter.NUpstreamPlanes = 5
         c.MuFilter.DownstreamDetX = c.MuFilter.X
         c.MuFilter.DownstreamDetY = c.MuFilter.FeY
-        c.MuFilter.DownstreamDetZ = 4*u.cm
+        c.MuFilter.DownstreamDetZ = 3.9*u.cm
         c.MuFilter.NDownstreamPlanes=3
 
         #upstream bars configuration
-        c.MuFilter.NUpstreamBars = 11
-        c.MuFilter.OverlapUpstreamBars = 0.5*u.cm
+        c.MuFilter.NUpstreamBars = 10
         c.MuFilter.UpstreamBarX = c.MuFilter.UpstreamDetX
-        c.MuFilter.UpstreamBarY = (c.MuFilter.UpstreamDetY + c.MuFilter.OverlapUpstreamBars * (c.MuFilter.NUpstreamBars - 1))/c.MuFilter.NUpstreamBars #computed for staggering
+        c.MuFilter.UpstreamBarY = c.MuFilter.UpstreamDetY/c.MuFilter.NUpstreamBars #computed for staggering
         c.MuFilter.UpstreamBarZ = 1*u.cm
 
         #downstream bars configuration
-        c.MuFilter.NDownstreamBars = 77 #n.d.r. both for x and y in this case
-        c.MuFilter.OverlapDownstreamBars = 0.2*u.cm
+        c.MuFilter.NDownstreamBars = 60 #n.d.r. both for x and y in this case
         c.MuFilter.DownstreamBarX = c.MuFilter.DownstreamDetX
-        c.MuFilter.DownstreamBarY = (c.MuFilter.DownstreamDetY + c.MuFilter.OverlapDownstreamBars * (c.MuFilter.NDownstreamBars - 1))/c.MuFilter.NDownstreamBars #computed for staggering
+        c.MuFilter.DownstreamBarY = c.MuFilter.DownstreamDetY/c.MuFilter.NDownstreamBars #computed for staggering
         c.MuFilter.DownstreamBarZ = 1*u.cm
 
-        c.MuFilter.DownstreamBarX_ver = (c.MuFilter.DownstreamDetX + c.MuFilter.OverlapDownstreamBars * (c.MuFilter.NDownstreamBars - 1))/c.MuFilter.NDownstreamBars
+        c.MuFilter.DownstreamBarX_ver = c.MuFilter.DownstreamDetX/c.MuFilter.NDownstreamBars
         c.MuFilter.DownstreamBarY_ver = c.MuFilter.DownstreamDetY
         c.MuFilter.DownstreamBarZ_ver = 1*u.cm
 
         #total z thickness and position
         c.MuFilter.Z = c.MuFilter.NUpstreamPlanes*(c.MuFilter.FeZ+c.MuFilter.UpstreamDetZ) + c.MuFilter.NDownstreamPlanes*(c.MuFilter.FeZ+c.MuFilter.DownstreamDetZ) 
         c.MuFilter.Zcenter = c.EmulsionDet.zC+c.EmulsionDet.zdim/2+c.MuFilter.Z/2
-        c.MuFilter.ShiftX = c.EmulsionDet.ShiftX
-        c.MuFilter.ShiftY = 3.55*u.cm+c.MuFilter.Y/2. #since y size increased of 0.5, we need to increase this shift from 3.3 to 3.55
+        c.MuFilter.ShiftX = -2.8 * u.cm - c.MuFilter.X/2.
+        
+        c.MuFilter.Slope = -3.2 #in degrees
+        c.MuFilter.ShiftY = 9.6 * u.cm + c.MuFilter.Y/2. #shift of first block of upstream section
+        c.MuFilter.ShiftYEnd= 7.5*u.cm + c.MuFilter.Y/2. #shift for downstream section

--- a/python/shipLHC_conf.py
+++ b/python/shipLHC_conf.py
@@ -61,19 +61,18 @@ def configure(run,ship_geo,Gfield=''):
  MuFilter.SetUpstreamPlanesDimensions(ship_geo.MuFilter.UpstreamDetX, ship_geo.MuFilter.UpstreamDetY, ship_geo.MuFilter.UpstreamDetZ)
  MuFilter.SetNUpstreamPlanes(ship_geo.MuFilter.NUpstreamPlanes)
  MuFilter.SetUpstreamBarsDimensions(ship_geo.MuFilter.UpstreamBarX, ship_geo.MuFilter.UpstreamBarY, ship_geo.MuFilter.UpstreamBarZ)
- MuFilter.SetOverlapUpstreamBars(ship_geo.MuFilter.OverlapUpstreamBars)
  MuFilter.SetNUpstreamBars(ship_geo.MuFilter.NUpstreamBars)
  #downstream section
  MuFilter.SetDownstreamPlanesDimensions(ship_geo.MuFilter.DownstreamDetX, ship_geo.MuFilter.DownstreamDetY, ship_geo.MuFilter.DownstreamDetZ)
  MuFilter.SetNDownstreamPlanes(ship_geo.MuFilter.NDownstreamPlanes)
  MuFilter.SetDownstreamBarsDimensions(ship_geo.MuFilter.DownstreamBarX, ship_geo.MuFilter.DownstreamBarY, ship_geo.MuFilter.DownstreamBarZ)
  MuFilter.SetDownstreamVerticalBarsDimensions(ship_geo.MuFilter.DownstreamBarX_ver, ship_geo.MuFilter.DownstreamBarY_ver, ship_geo.MuFilter.DownstreamBarZ_ver)
- MuFilter.SetOverlapDownstreamBars(ship_geo.MuFilter.OverlapDownstreamBars)
  MuFilter.SetNDownstreamBars(ship_geo.MuFilter.NDownstreamBars)
 
  MuFilter.SetCenterZ(ship_geo.MuFilter.Zcenter)
  MuFilter.SetXYDisplacement(ship_geo.MuFilter.ShiftX, ship_geo.MuFilter.ShiftY)
- MuFilter.SetYPlanesDisplacement(ship_geo.MuFilter.ShiftDY)
+ MuFilter.SetSlope(ship_geo.MuFilter.Slope)
+ MuFilter.SetYPlanesDisplacement(ship_geo.MuFilter.ShiftYEnd)
  detectorList.append(MuFilter)
 
  for x in detectorList:

--- a/shipLHC/MuFilter.cxx
+++ b/shipLHC/MuFilter.cxx
@@ -307,7 +307,7 @@ void MuFilter::ConstructGeometry()
 	  volDownstreamDet->AddNode(volMuDownstreamBar_hor,ibar+1E+3,yztrans);
 	  //adding vertical bars for x
 
-	  Double_t dx_bar = -fDownstreamDetX/2 + fDownstreamBarX_ver/2. + fDownstreamBarX_ver*ibar; 
+	  Double_t dx_bar = -fDownstreamDetY/2 + fDownstreamBarX_ver/2. + fDownstreamBarX_ver*ibar; //they do not cover all the x region, but only 60 x 60.
           Double_t dz_bar_ver = -fDownstreamDetZ/2. + 2*fDownstreamBarZ + fDownstreamBarZ/2.;
 
 	  TGeoTranslation *xztrans = new TGeoTranslation(dx_bar,0,dz_bar_ver);

--- a/shipLHC/MuFilter.h
+++ b/shipLHC/MuFilter.h
@@ -34,21 +34,20 @@ class MuFilter : public FairDetector
 		void SetIronBlockDimensions(Double_t , Double_t, Double_t);	       
 		void SetMuFilterDimensions(Double_t, Double_t, Double_t);
 		void SetCenterZ(Double_t);
-		void SetXYDisplacement(Double_t , Double_t );
-		void SetYPlanesDisplacement(Double_t);
+                void SetXYDisplacement(Double_t , Double_t ); //global xy position
+                void SetYPlanesDisplacement(Double_t); //displacement for downstream plates
+                void SetSlope(Double_t);
 
 		void SetUpstreamPlanesDimensions(Double_t, Double_t, Double_t);
 		void SetNUpstreamPlanes(Int_t);
 		void SetUpstreamBarsDimensions(Double_t, Double_t, Double_t);
 		void SetNUpstreamBars(Int_t);
-		void SetOverlapUpstreamBars(Double_t);
 
 		void SetDownstreamPlanesDimensions(Double_t, Double_t, Double_t);
 		void SetNDownstreamPlanes(Int_t);
 		void SetDownstreamBarsDimensions(Double_t, Double_t, Double_t);
                 void SetDownstreamVerticalBarsDimensions(Double_t, Double_t, Double_t);
 		void SetNDownstreamBars(Int_t);
-		void SetOverlapDownstreamBars(Double_t);
 
 		
 
@@ -87,7 +86,7 @@ class MuFilter : public FairDetector
 		MuFilter(const MuFilter&);
 		MuFilter& operator=(const MuFilter&);
 
-		ClassDef(MuFilter,2)
+		ClassDef(MuFilter,3)
 
 	private:
 
@@ -114,8 +113,7 @@ class MuFilter : public FairDetector
 
 			Double_t fUpstreamDetX;	//|Upstream muon detector planes dimensions
 			Double_t fUpstreamDetY;	//|
-			Double_t fUpstreamDetZ;	//|
-			Double_t fUpstreamBarOverlap; //|Size of overlap (staggering)
+			Double_t fUpstreamDetZ;	//|			
 
 			Int_t fNUpstreamPlanes;	//|Number of planes
 
@@ -133,8 +131,7 @@ class MuFilter : public FairDetector
 
 			Double_t fDownstreamBarX; //|Staggered bars of upstream section
 			Double_t fDownstreamBarY;
-			Double_t fDownstreamBarZ;
-			Double_t fDownstreamBarOverlap; //|Size of overlap (staggering)
+			Double_t fDownstreamBarZ;			
 
 		        Int_t fNDownstreamBars;   //|Number of staggered bars
 
@@ -145,7 +142,8 @@ class MuFilter : public FairDetector
 			Double_t fCenterZ;	//|Zposition of the muon filter
 			Double_t fShiftX;	//|Shift in x-y wrt beam line
 			Double_t fShiftY;	//|
-			Double_t fShiftDY;	//|Shift in DY of the first 6 planes (2 cm)
+                        Double_t fShiftYEnd;    //|Shift for Downstream station
+                        Double_t fSlope; //Slope for floor
 
 			Int_t InitMedium(const char* name);
 };


### PR DESCRIPTION
Dear all,

I have developed this commit from the updated structure presented in the TP draft, and the details in the e-mails exchanged with @ThomasRuf  and Antonia Di Crescenzo. I summarize here the main points:

1) The dimensions of the Muon Filter are 80 x 60 (active area only implemented): see figure 29 in the TP for source material.

2) Still from the TP, there is no staggering anymore, and we have 10 bars in the upstream section per station, and 60 bars in the downstream section per station (horizontal and vertical bars).

3) The positions of the iron blocks have been set according to the information provided by Antonia. Thomas suggested to use directly the slope to compute the block shift along y, so I have adapted the code accordingly, using the provided slope of 3.2 degrees. The three downstream blocks are instead at the same height, 7.5 cm from the beam (origin).

I have tested for overlaps, also by merging it with the tunnel branch from Thomas. I did not encounter any overlap. 
Of course, I would like to ask Thomas for confirmation: I hope this does not overlap even using the original tunnel configuration, before the applied ad-hoc fixes. Could you check that, please?

I wait for your revisions and comments.

Best regards,
Antonio