### PR TITLE
Addition of veto planes

### DIFF
--- a/geometry/shipLHC_geom_config.py
+++ b/geometry/shipLHC_geom_config.py
@@ -37,7 +37,7 @@ with ConfigRegistry.register_config("basic") as c:
         c.EmulsionDet.WallYDim = c.EmulsionDet.ydim
         c.EmulsionDet.WallZDim = c.EmulsionDet.BrZ
         c.EmulsionDet.TTz = 3.0*u.cm
-        c.EmulsionDet.zdim = c.EmulsionDet.wall* c.EmulsionDet.WallZDim + (c.EmulsionDet.wall+1)*c.EmulsionDet.TTz
+        c.EmulsionDet.zdim = c.EmulsionDet.wall* c.EmulsionDet.WallZDim + c.EmulsionDet.wall*c.EmulsionDet.TTz
         c.EmulsionDet.ShiftX = -8.0*u.cm - c.EmulsionDet.xdim/2.
         c.EmulsionDet.ShiftY = 15.5*u.cm + c.EmulsionDet.ydim/2.
 

--- a/geometry/shipLHC_geom_config.py
+++ b/geometry/shipLHC_geom_config.py
@@ -46,9 +46,28 @@ with ConfigRegistry.register_config("basic") as c:
         c.Scifi.ydim = c.EmulsionDet.ydim
         c.Scifi.zdim = c.EmulsionDet.TTz
         c.Scifi.DZ = c.EmulsionDet.BrZ
-        c.Scifi.nplanes = c.EmulsionDet.wall+1
+        c.Scifi.nplanes = c.EmulsionDet.wall
 
         c.MuFilter = AttrDict(z=0*u.cm)
+        #Veto station parameters
+        c.MuFilter.NVetoPlanes = 2
+        c.MuFilter.VetoShiftX = c.EmulsionDet.ShiftX
+        c.MuFilter.VetoShiftY = c.EmulsionDet.ShiftY
+        c.MuFilter.VetoPlaneShiftY = 1*u.cm
+        
+        c.MuFilter.VetoPlaneX = 42 *u.cm
+        c.MuFilter.VetoPlaneY = 42 *u.cm
+        c.MuFilter.VetoPlaneZ = 4 * u.cm
+
+        c.MuFilter.NVetoBars = 7
+
+        c.MuFilter.VetoBarX = c.MuFilter.VetoPlaneX
+        c.MuFilter.VetoBarY = c.MuFilter.VetoPlaneY / c.MuFilter.NVetoBars
+        c.MuFilter.VetoBarZ = 1 * u.cm
+
+        #veto should end at the start of first ECC target
+        c.MuFilter.VetozC = c.EmulsionDet.zC - c.EmulsionDet.zdim/2. - (c.MuFilter.NVetoPlanes * c.MuFilter.VetoPlaneZ)/2.
+
         #c.MuFilter.X = c.EmulsionDet.xdim + 20*u.cm
         c.MuFilter.X = 80.0*u.cm
         #c.MuFilter.Y = c.EmulsionDet.ydim + 20*u.cm+10.0*u.cm

--- a/geometry/shipLHC_geom_config.py
+++ b/geometry/shipLHC_geom_config.py
@@ -9,7 +9,6 @@ with ConfigRegistry.register_config("basic") as c:
 
         c.EmulsionDet = AttrDict(z=0*u.cm)
         c.EmulsionDet.PassiveOption = 1 #0 makes emulsion volumes active, 1 makes all emulsion volumes passive
-        c.EmulsionDet.zC = 0*u.m
         c.EmulsionDet.row = 2
         c.EmulsionDet.col = 2
         c.EmulsionDet.wall= 5
@@ -40,6 +39,9 @@ with ConfigRegistry.register_config("basic") as c:
         c.EmulsionDet.zdim = c.EmulsionDet.wall* c.EmulsionDet.WallZDim + c.EmulsionDet.wall*c.EmulsionDet.TTz
         c.EmulsionDet.ShiftX = -8.0*u.cm - c.EmulsionDet.xdim/2.
         c.EmulsionDet.ShiftY = 15.5*u.cm + c.EmulsionDet.ydim/2.
+
+        c.EmulsionDet.startpos =  -25.4750 * u.cm
+        c.EmulsionDet.zC = c.EmulsionDet.startpos + c.EmulsionDet.zdim/2.
 
         c.Scifi = AttrDict(z=0*u.cm)
         c.Scifi.xdim = c.EmulsionDet.xdim

--- a/python/shipLHC_conf.py
+++ b/python/shipLHC_conf.py
@@ -56,6 +56,14 @@ def configure(run,ship_geo,Gfield=''):
  detectorList.append(Scifi)
 
  MuFilter = ROOT.MuFilter("MuFilter",ROOT.kTRUE)
+ #upstream veto section
+ MuFilter.SetVetoCenterPosition(ship_geo.MuFilter.VetozC)
+ MuFilter.SetVetoShift(ship_geo.MuFilter.VetoShiftX, ship_geo.MuFilter.VetoShiftY)
+ MuFilter.SetVetoPlaneShiftY(ship_geo.MuFilter.VetoPlaneShiftY)
+ MuFilter.SetNVetoPlanes(ship_geo.MuFilter.NVetoPlanes)
+ MuFilter.SetNVetoBars(ship_geo.MuFilter.NVetoBars)
+ MuFilter.SetVetoPlanesDimensions(ship_geo.MuFilter.VetoPlaneX, ship_geo.MuFilter.VetoPlaneY, ship_geo.MuFilter.VetoPlaneZ)
+ MuFilter.SetVetoBarsDimensions(ship_geo.MuFilter.VetoBarX, ship_geo.MuFilter.VetoBarY, ship_geo.MuFilter.VetoBarZ)
  MuFilter.SetMuFilterDimensions(ship_geo.MuFilter.X, ship_geo.MuFilter.Y, ship_geo.MuFilter.Z)
  MuFilter.SetIronBlockDimensions(ship_geo.MuFilter.FeX, ship_geo.MuFilter.FeY, ship_geo.MuFilter.FeZ)
  #upstream section

--- a/shipLHC/EmulsionDet.cxx
+++ b/shipLHC/EmulsionDet.cxx
@@ -282,8 +282,7 @@ void EmulsionDet::ConstructGeometry()
 
 	//adding walls
 
-        Double_t d_cl_z = - ZDimension/2 + TTrackerZ;
-	Double_t d_tt = -ZDimension/2 + TTrackerZ/2;
+        Double_t d_cl_z = - ZDimension/2;
 
 	for(int l = 0; l < fNWall; l++)
 	  {

--- a/shipLHC/MuFilter.h
+++ b/shipLHC/MuFilter.h
@@ -31,6 +31,14 @@ class MuFilter : public FairDetector
 		void ConstructGeometry();
 
 		/** Other functions **/
+		void SetVetoCenterPosition(Double_t); //veto position
+		void SetNVetoPlanes(Int_t); //number of veto planes
+		void SetNVetoBars(Int_t);
+		void SetVetoShift(Double_t , Double_t);
+		void SetVetoPlaneShiftY(Double_t);		
+		void SetVetoPlanesDimensions(Double_t, Double_t, Double_t);	
+		void SetVetoBarsDimensions(Double_t, Double_t, Double_t);
+		
 		void SetIronBlockDimensions(Double_t , Double_t, Double_t);	       
 		void SetMuFilterDimensions(Double_t, Double_t, Double_t);
 		void SetCenterZ(Double_t);
@@ -86,7 +94,7 @@ class MuFilter : public FairDetector
 		MuFilter(const MuFilter&);
 		MuFilter& operator=(const MuFilter&);
 
-		ClassDef(MuFilter,3)
+		ClassDef(MuFilter,4)
 
 	private:
 
@@ -103,6 +111,22 @@ class MuFilter : public FairDetector
 			TClonesArray*  fMuFilterPointCollection;
 
 	protected:
+			Double_t fVetoShiftX;  //|Shift of Veto with respect to beam line
+			Double_t fVetoShiftY;  //|
+			
+			Double_t fVetoPlaneX;  //|Veto Plane dimensions
+			Double_t fVetoPlaneY;  //|
+			Double_t fVetoPlaneZ;  //|
+			
+			Double_t fVetoBarX;    //!Veto Bar dimensions
+			Double_t fVetoBarY;
+			Double_t fVetoBarZ;
+			
+			Double_t fVetoCenterZ;
+			Int_t fNVetoPlanes;
+			Int_t fNVetoBars;
+			Double_t fVetoPlaneShiftY;			
+			
 			Double_t fMuFilterX;	//|MuonFilterBox dimensions
 			Double_t fMuFilterY;	//|
 			Double_t fMuFilterZ;	//|

--- a/shipLHC/Scifi.cxx
+++ b/shipLHC/Scifi.cxx
@@ -133,8 +133,8 @@ void Scifi::ConstructGeometry()
 	Int_t n = 0;
 	for(int i=0;i<fNplanes;i++)
 	{		
-		volTarget->AddNode(volScifi,n,new TGeoTranslation(0,0, d_tt+i*(ZDimension+DeltaZ)));
-		n++;
+	  volTarget->AddNode(volScifi,n,new TGeoTranslation(0,0, DeltaZ + d_tt+i*(ZDimension+DeltaZ))); //target starts with first wall
+	  n++;
 	}   
 }
 


### PR DESCRIPTION
Dear all,

as discussed after last meeting, I have added the two veto planes in place of the first SciFi.
The addition is done from the MuFilter class. This seems to me the more conservative option, for now: if in future we will need a new separate class, we can just move the volume there.

The geometry follows the TP description: 2 stations of 7 bars each, with a relative vertical shift of 1 cm between the stations.
Only the active area is implemented, just as in the muon filter stations. Display can be seen here:

![geometry_with_tunnel](https://user-images.githubusercontent.com/18480751/104727961-7c49e480-5736-11eb-9ede-e046a5635c2f.png)

I have checked that there are no overlaps, from the run_simScript debug option.
I will now wait for your comments.

Best regards,
Antonio Iuliano