### PR TITLE
Fixing overlaps of emulsion volumes and positioning in GenieGenerator

### DIFF
--- a/geometry/sndLHC_geom_config.py
+++ b/geometry/sndLHC_geom_config.py
@@ -39,13 +39,13 @@ with ConfigRegistry.register_config("basic") as c:
         c.EmulsionDet.WallYDim = 38.6 *u.cm
         c.EmulsionDet.WallZDim = 8.15 *u.cm
         c.EmulsionDet.WallZBorder_offset = 4.75 * u.mm
-        c.EmulsionDet.TTz = 3.0*u.cm
-        c.EmulsionDet.zdim = c.EmulsionDet.wall* c.EmulsionDet.TotalWallZDim + c.EmulsionDet.wall*c.EmulsionDet.TTz
+        c.EmulsionDet.TTz = 3.0*u.cm     
         c.EmulsionDet.ShiftX = -8.0*u.cm - c.EmulsionDet.xdim/2.
         c.EmulsionDet.ShiftY = 15.5*u.cm + c.EmulsionDet.ydim/2.
 
         c.EmulsionDet.startpos =  289.3369 *u.cm #value from getGeoInformation output
         c.EmulsionDet.zC = 321.3055 * u.cm #value from getGeoInformation output
+        c.EmulsionDet.zdim = (c.EmulsionDet.zC - c.EmulsionDet.startpos)*2 #scifi volume thickness is not equal to c.EmulsionDet.TTz anymore, getting zdim from positions
         
         # survey points in survey coordinate system!
         c.EmulsionDet.Xpos0 = 5.74

--- a/geometry/sndLHC_geom_config.py
+++ b/geometry/sndLHC_geom_config.py
@@ -44,8 +44,8 @@ with ConfigRegistry.register_config("basic") as c:
         c.EmulsionDet.ShiftX = -8.0*u.cm - c.EmulsionDet.xdim/2.
         c.EmulsionDet.ShiftY = 15.5*u.cm + c.EmulsionDet.ydim/2.
 
-        c.EmulsionDet.startpos =  -25.4750 * u.cm + c.EmulsionDet.z
-        c.EmulsionDet.zC = c.EmulsionDet.startpos + c.EmulsionDet.zdim/2.
+        c.EmulsionDet.startpos =  289.3369 *u.cm #value from getGeoInformation output
+        c.EmulsionDet.zC = 321.3055 * u.cm #value from getGeoInformation output
         
         # survey points in survey coordinate system!
         c.EmulsionDet.Xpos0 = 5.74

--- a/shipLHC/EmulsionDet.cxx
+++ b/shipLHC/EmulsionDet.cxx
@@ -262,8 +262,8 @@ void EmulsionDet::ConstructGeometry()
 
 	for(int l = 0; l < fNWall; l++)
 	  {
-		volTarget->AddNode(volWallborder,l,new TGeoTranslation(-dx_survey[l]-XDimension/2., dz_survey[l]+YDimension/2., dy_survey[l]+BrickZ/2.)); //the survey points refer to the down-left corner
-		volTarget->AddNode(volWall,l,new TGeoTranslation(-dx_survey[l]-XDimension/2., dz_survey[l]+YDimension/2., dy_survey[l]+BrickZ/2.+WallZBorder_offset)); //the survey points refer to the down-left corner
+		volTarget->AddNode(volWallborder,l,new TGeoTranslation(-dx_survey[l]-XDimension/2., dz_survey[l]+YDimension/2., dy_survey[l]+TotalWallZDim/2.)); //the survey points refer to the down-left corner
+		volTarget->AddNode(volWall,l,new TGeoTranslation(-dx_survey[l]-XDimension/2., dz_survey[l]+YDimension/2., dy_survey[l]+TotalWallZDim/2.+WallZBorder_offset)); //the survey points refer to the down-left corner
 		d_cl_z += BrickZ + TTrackerZ;
 	  }
 


### PR DESCRIPTION
Dear @ThomasRuf and all sndsw users,

I have checked the updated master branch. I have found the following issues:

* volWallborder overlap with ScifiVolume. This appears to be due to setting the center of the wall volume from the border with BrickZ, instead of TotalWallZDim, which includes the wall border;
* Even if c.EmulsionDet.zC is not used in the geometry construction anymore, it is still called for setting the position of neutrino events in GenieGen.SetPositions(). Therefore, it must be updated to the new positions, otherwise the neutrino events would not be generated along the target z. For now, I have put the values by hand.

Suggestions to improve are welcome.
Best regards,
Antonio