### PR TITLE
Fixing fibre detector ID bug

### DIFF
--- a/shipLHC/Scifi.cxx
+++ b/shipLHC/Scifi.cxx
@@ -232,10 +232,6 @@ void Scifi::ConstructGeometry()
   PlasticAirVolume->AddNode(PlasticBarVolume, 0, new TGeoTranslation(- fXDimension/2 + fXPlastBar/2, 0, 0));  //bars are placed || to y
   PlasticAirVolume->AddNode(PlasticBarVolume, 1, new TGeoTranslation(+ fXDimension/2 - fXPlastBar/2, 0, 0));
 
-  //SciFi mats for X and Y fiber planes
-  TGeoVolume *HorMatVolume  = gGeoManager->MakeBox("HorMatVolume", Epoxy, fLengthScifiMat/2, fWidthScifiMat/2, fZEpoxyMat/2); 
-  TGeoVolume *VertMatVolume = gGeoManager->MakeBox("VertMatVolume", Epoxy, fWidthScifiMat/2, fLengthScifiMat/2, fZEpoxyMat/2); 
-
   //Fiber volume that contains the scintillating core and double cladding
   TGeoVolumeAssembly *FiberVolume = new TGeoVolumeAssembly("FiberVolume");
 
@@ -296,6 +292,10 @@ void Scifi::ConstructGeometry()
  
     for (int imat = 0; imat < fNMats; imat++){
         
+        //SciFi mats for X and Y fiber planes
+        TGeoVolume *HorMatVolume  = gGeoManager->MakeBox("HorMatVolume", Epoxy, fLengthScifiMat/2, fWidthScifiMat/2, fZEpoxyMat/2); 
+        TGeoVolume *VertMatVolume = gGeoManager->MakeBox("VertMatVolume", Epoxy, fWidthScifiMat/2, fLengthScifiMat/2, fZEpoxyMat/2); 
+ 
         //Placing mats along Y 
         ScifiHorPlaneVol->AddNode(HorMatVolume, 1e6*(istation+1) + 1e4*(imat + 1), new TGeoTranslation(0, (imat-1)*(fWidthScifiMat+fGapScifiMat), 0));
         

--- a/shipLHC/Scifi.cxx
+++ b/shipLHC/Scifi.cxx
@@ -232,6 +232,10 @@ void Scifi::ConstructGeometry()
   PlasticAirVolume->AddNode(PlasticBarVolume, 0, new TGeoTranslation(- fXDimension/2 + fXPlastBar/2, 0, 0));  //bars are placed || to y
   PlasticAirVolume->AddNode(PlasticBarVolume, 1, new TGeoTranslation(+ fXDimension/2 - fXPlastBar/2, 0, 0));
 
+  //SciFi mats for X and Y fiber planes
+  TGeoVolume *HorMatVolume  = gGeoManager->MakeBox("HorMatVolume", Epoxy, fLengthScifiMat/2, fWidthScifiMat/2, fZEpoxyMat/2); 
+  TGeoVolume *VertMatVolume = gGeoManager->MakeBox("VertMatVolume", Epoxy, fWidthScifiMat/2, fLengthScifiMat/2, fZEpoxyMat/2); 
+
   //Fiber volume that contains the scintillating core and double cladding
   TGeoVolumeAssembly *FiberVolume = new TGeoVolumeAssembly("FiberVolume");
 
@@ -292,10 +296,6 @@ void Scifi::ConstructGeometry()
  
     for (int imat = 0; imat < fNMats; imat++){
         
-        //SciFi mats for X and Y fiber planes
-        TGeoVolume *HorMatVolume  = gGeoManager->MakeBox("HorMatVolume", Epoxy, fLengthScifiMat/2, fWidthScifiMat/2, fZEpoxyMat/2); 
-        TGeoVolume *VertMatVolume = gGeoManager->MakeBox("VertMatVolume", Epoxy, fWidthScifiMat/2, fLengthScifiMat/2, fZEpoxyMat/2); 
- 
         //Placing mats along Y 
         ScifiHorPlaneVol->AddNode(HorMatVolume, 1e6*(istation+1) + 1e4*(imat + 1), new TGeoTranslation(0, (imat-1)*(fWidthScifiMat+fGapScifiMat), 0));
         

--- a/shipLHC/Scifi.cxx
+++ b/shipLHC/Scifi.cxx
@@ -265,13 +265,11 @@ void Scifi::ConstructGeometry()
     zPosM =  -fZScifiMat/2 + fClad2_rmax/2 + irow*fVertPitch;
     if (irow%2 == 0){
       for (int ifiber = 0; ifiber < fNFibers_Srow; ifiber++){
-	//HorMatVolume->AddNode(FiberVolume, 1e6*(istation+1) + 1e4*(imat + 1) + 1e3*(irow + 1) + ifiber + 1, new TGeoCombiTrans("rottranshor0", 0, offsetS + ifiber*fHorPitch, zPosM, rothorfiber));
 	HorMatVolume->AddNode(FiberVolume, 1e3*(irow + 1) + ifiber + 1, new TGeoCombiTrans("rottranshor0", 0, offsetS + ifiber*fHorPitch, zPosM, rothorfiber));
       }
     }
     else{
       for (int ifiber = 0; ifiber < fNFibers_Lrow; ifiber++){
-	//HorMatVolume->AddNode(FiberVolume, 1e6*(istation+1) + 1e4*(imat + 1) + 1e3*(irow + 1) + ifiber + 1, new TGeoCombiTrans("rottranshor1", 0, offsetL + ifiber*fHorPitch, zPosM, rothorfiber));
 	HorMatVolume->AddNode(FiberVolume, 1e3*(irow + 1) + ifiber + 1, new TGeoCombiTrans("rottranshor1", 0, offsetL + ifiber*fHorPitch, zPosM, rothorfiber));
       }
     }
@@ -281,13 +279,11 @@ void Scifi::ConstructGeometry()
   for (int irow = 0; irow < fNFibers_z; irow++){
     if (irow%2 == 0){
       for (int ifiber = 0; ifiber < fNFibers_Srow; ifiber++){
-	//VertMatVolume->AddNode(FiberVolume, 1e6*(istation+1) + 1e5 + 1e4*(imat + 1) + 1e3*(irow + 1) + ifiber + 1, new TGeoCombiTrans("rottransvert0", offsetS + ifiber*fHorPitch, 0, zPosM, rotvertfiber));
 	VertMatVolume->AddNode(FiberVolume, 1e5 + 1e3*(irow + 1) + ifiber + 1, new TGeoCombiTrans("rottransvert0", offsetS + ifiber*fHorPitch, 0, zPosM, rotvertfiber));
       }
     }
     else{
       for (int ifiber = 0; ifiber < fNFibers_Lrow; ifiber++){
-	//VertMatVolume->AddNode(FiberVolume, 1e6*(istation+1) + 1e5 + 1e4*(imat + 1) + 1e3*(irow + 1) + ifiber + 1, new TGeoCombiTrans("rottransvert1", offsetL + ifiber*fHorPitch, 0, zPosM, rotvertfiber));
 	VertMatVolume->AddNode(FiberVolume, 1e5 + 1e3*(irow + 1) + ifiber + 1, new TGeoCombiTrans("rottransvert1", offsetL + ifiber*fHorPitch, 0, zPosM, rotvertfiber));
       }
     }


### PR DESCRIPTION
A bug was introduced in commit [0fa9815](https://github.com/SND-LHC/sndsw/commit/0fa98159e41d1b8859dc0c36b2484bd0c5ff042d) where the fibre detector IDs are repeated in all 5 stations.

## Steps to reproduce:
- Generate 200 background muon events:
```bash
python $SNDSW_ROOT/shipLHC/run_simSND.py --Ntuple -n 200 -i 0 -f /eos/experiment/sndlhc/MonteCarlo/FLUKA/muons_down/muons_VCdown_IR1-LHC.root -o test_mu/
```
- Print the ScifiPoint positions and detector IDs:
```bash
root -l test_mu/sndLHC.Ntuple-TGeant4.root 
```
```C++
cbmsim->Scan("ScifiPoint.fX:ScifiPoint.fY:ScifiPoint.fZ:ScifiPoint.GetDetectorID():ScifiPoint.station()", "Length$(ScifiPoint)>0")
```
Get a result like this:
```
***********************************************************************************
*    Row   * Instance * ScifiPoin * ScifiPoin * ScifiPoin * ScifiPoin * ScifiPoin *
***********************************************************************************
*       30 *        0 * -14.23125 * 17.698501 * 299.85122 *   1012121 *         1 *
*       30 *        1 * -14.23123 * 17.698534 * 299.87243 *   1013121 *         1 *
*       30 *        2 * -14.23120 * 17.698566 * 299.89321 *   1014121 *         1 *
*       30 *        3 * -14.23118 * 17.698598 * 299.91442 *   1015121 *         1 *
*       30 *        4 * -14.23115 * 17.698631 * 299.93524 *   1016121 *         1 *
*       30 *        5 * -14.23046 * 17.699491 * 300.49533 *   1111225 *         1 *
*       30 *        6 * -14.21510 * 17.717855 * 312.83145 *   1011127 *         1 *
*       30 *        7 * -14.21507 * 17.717886 * 312.85263 *   1012128 *         1 *
*       30 *        8 * -14.21505 * 17.717914 * 312.87344 *   1013127 *         1 *
*       30 *        9 * -14.21502 * 17.717945 * 312.89465 *   1014128 *         1 *
*       30 *       10 * -14.21499 * 17.717973 * 312.91543 *   1015127 *         1 *
*       30 *       11 * -14.21497 * 17.718004 * 312.93664 *   1016128 *         1 *
*       30 *       12 * -14.21427 * 17.718792 * 313.49658 *   1112226 *         1 *
*       30 *       13 * -14.19904 * 17.735834 * 325.83285 *   1011134 *         1 *
*       30 *       14 * -14.19902 * 17.735864 * 325.85366 *   1012134 *         1 *
*       30 *       15 * -14.19899 * 17.735893 * 325.87484 *   1013134 *         1 *
*       30 *       16 * -14.19897 * 17.735921 * 325.89566 *   1014134 *         1 *
*       30 *       17 * -14.19894 * 17.735952 * 325.91687 *   1015134 *         1 *
*       30 *       18 * -14.19892 * 17.735981 * 325.93768 *   1016134 *         1 *
*       30 *       19 * -14.19826 * 17.736764 * 326.49780 *   1111226 *         1 *
*       30 *       20 * -14.18402 * 17.754217 * 338.83389 *   1011140 *         1 *
*       30 *       21 * -14.18400 * 17.754247 * 338.85507 *   1012141 *         1 *
```
The ScifiPoint location appears to be correct, but the detector ID and station number do not match the position of the point.

## Cause
The `HorMatVolume` and `VertMatVolume` object initializations were moved outside of the `imat` loop. Therefore the same `HorMatVolume` and `VertMatVolume` objects (containing always the same fibres, with the same detector IDs) were positioned in the five stations.

## Fix
In `Scifi::ProcessHits`, get the station and mat numbers from the mat volume and not from the fibre volume.
Take the opportunity to also move the fibre placement code outside of the `imat` and `istation` loops.
Get expected behaviour:
```
***********************************************************************************
*    Row   * Instance * ScifiPoin * ScifiPoin * ScifiPoin * ScifiPoin * ScifiPoin *
***********************************************************************************
*       30 *        0 * -18.62435 * 13.726564 * 352.45010 *   5131064 *         5 *
*       30 *        1 * -18.62413 * 13.727275 * 352.45959 *   5132065 *         5 *
*       53 *        0 * -16.84821 * 45.877697 * 300.18109 *   1031198 *         1 *
*       53 *        1 * -16.84819 * 45.877780 * 300.20187 *   1032198 *         1 *
*       53 *        2 * -16.84818 * 45.877868 * 300.22308 *   1033198 *         1 *
*       53 *        3 * -16.84817 * 45.877956 * 300.24386 *   1034198 *         1 *
*       53 *        4 * -16.84816 * 45.878044 * 300.26507 *   1035198 *         1 *
*       53 *        5 * -16.84815 * 45.878131 * 300.28585 *   1036198 *         1 *
*       53 *        6 * -16.84782 * 45.880458 * 300.84600 *   1132137 *         1 *
*       53 *        7 * -16.83949 * 45.934082 * 313.20361 *   2032206 *         2 *
*       53 *        8 * -16.83947 * 45.934284 * 313.24560 *   2034206 *         2 *
*       53 *        9 * -16.83944 * 45.934486 * 313.28759 *   2036206 *         2 *
*       53 *       10 * -16.83910 * 45.937213 * 313.84771 *   2131137 *         2 *
*       53 *       11 * -16.83074 * 45.991531 * 326.20535 *   3032214 *         3 *
*       53 *       12 * -16.83071 * 45.991722 * 326.24734 *   3034214 *         3 *
*       53 *       13 * -16.83068 * 45.991916 * 326.28933 *   3036214 *         3 *
*       53 *       14 * -16.83030 * 45.994480 * 326.84942 *   3132138 *         3 *
*       53 *       15 * -16.82058 * 46.046615 * 339.18585 *   4031221 *         4 *
*       53 *       16 * -16.82056 * 46.046707 * 339.20709 *   4032222 *         4 *
*       53 *       17 * -16.82051 * 46.046890 * 339.24908 *   4034222 *         4 *
*       53 *       18 * -16.82046 * 46.047069 * 339.29107 *   4036222 *         4 *
*       53 *       19 * -16.81983 * 46.049491 * 339.85113 *   4132138 *         4 *
*       53 *       20 * -16.81012 * 46.103931 * 352.18759 *   5031229 *         5 *
*       53 *       21 * -16.81011 * 46.104030 * 352.20883 *   5032230 *         5 *
*       53 *       22 * -16.81011 * 46.104129 * 352.22958 *   5033229 *         5 *
```

## OLD Fix [OBSOLETE]
Move initialization back into the `imat` loop.
Get expected behaviour:
```
***********************************************************************************
*    Row   * Instance * ScifiPoin * ScifiPoin * ScifiPoin * ScifiPoin * ScifiPoin *
***********************************************************************************
*       30 *        0 * -19.69623 * 13.716738 *  351.7854 *   5011001 *         5 *
*       30 *        1 * -19.69623 * 13.716770 * 351.80618 *   5012001 *         5 *
*       30 *        2 * -19.69622 * 13.716801 * 351.82739 *   5013001 *         5 *
*       30 *        3 * -19.69622 * 13.716833 * 351.84820 *   5014001 *         5 *
*       30 *        4 * -19.69622 * 13.716864 * 351.86938 *   5015001 *         5 *
*       30 *        5 * -19.69622 * 13.716896 * 351.89019 *   5016001 *         5 *
*      124 *        0 * -9.221801 * 41.161037 * 339.79284 *   4131413 *         4 *
*      124 *        1 * -9.228876 * 41.165557 * 339.78112 *   4132413 *         4 *
*      124 *        2 * -9.594633 * 41.450687 * 339.23184 *   4036053 *         4 *
*      124 *        3 * -9.615608 * 41.434200 * 339.21298 *   4035052 *         4 *
*      124 *        4 * -9.639761 * 41.419578 * 339.19213 *   4034052 *         4 *
*      124 *        5 * -9.672759 * 41.408042 * 339.16967 *   4033051 *         4 *
*      124 *        6 * -9.710191 * 41.402675 * 339.14852 *   4032051 *         4 *
*      124 *        7 * -9.754261 * 41.399395 * 339.13229 *   4031051 *         4 *
*      128 *        0 * -20.60213 * 37.939743 * 300.08248 *   1021384 *         1 *
*      128 *        1 * -20.60217 * 37.939720 * 300.12448 *   1023384 *         1 *
*      128 *        2 * -20.60220 * 37.939693 * 300.16650 *   1025384 *         1 *
*      128 *        3 * -20.61298 * 37.932418 * 313.08355 *   2021390 *         2 *
*      128 *        4 * -20.61300 * 37.932407 * 313.10437 *   2022390 *         2 *
*      128 *        5 * -20.61302 * 37.932395 * 313.12554 *   2023390 *         2 *
*      128 *        6 * -20.61303 * 37.932384 * 313.14636 *   2024390 *         2 *
*      128 *        7 * -20.61305 * 37.932369 * 313.16754 *   2025390 *         2 *
*      128 *        8 * -20.61307 * 37.932357 * 313.18838 *   2026390 *         2 *
*      128 *        9 * -20.62369 * 37.924762 * 326.08425 *   3021395 *         3 *
*      128 *       10 * -20.62371 * 37.924751 * 326.10543 *   3022396 *         3 *
```