### PR TITLE
Fixing neutrino vertex bug

### DIFF
--- a/shipLHC/EmulsionDet.cxx
+++ b/shipLHC/EmulsionDet.cxx
@@ -162,7 +162,6 @@ TString EmulsionDet::PathBrickID(Int_t detID){
 void EmulsionDet::ConstructGeometry()
 {
 	// configuration parameters
-	fCenterZ        = conf_floats["EmulsionDet/zC"];
 	XDimension = conf_floats["EmulsionDet/xdim"];
 	YDimension = conf_floats["EmulsionDet/ydim"];
 	ZDimension = conf_floats["EmulsionDet/zdim"];
@@ -198,7 +197,6 @@ void EmulsionDet::ConstructGeometry()
 	if(!top)  LOG(ERROR) << "no Detector volume found " ;
 	gGeoManager->SetVisLevel(10);
 
-	LOG(INFO) << "fCenterZ:   "<<fCenterZ;
         LOG(INFO) << "    X: "<< XDimension<< "  "<< YDimension<<"   Z: "<<ZDimension;
 	LOG(INFO) <<"  BrickX: "<< BrickX<<"  Y: "<< BrickY<< "  Z: "<< BrickZ;
 	//Materials 

--- a/shipLHC/EmulsionDet.h
+++ b/shipLHC/EmulsionDet.h
@@ -100,8 +100,6 @@ protected:
     Double_t YDimension;
     Double_t ZDimension; 
 
-    Double_t fCenterZ;
-
     Int_t fNWall, fNRow, fNCol;
     Int_t fNTarget;
     Int_t number_of_plates; ////

--- a/shipLHC/run_simSND.py
+++ b/shipLHC/run_simSND.py
@@ -194,7 +194,6 @@ if simEngine=="Genie":
    Geniegen.Init(inputFile,options.firstEvent)
    Geniegen.SetCrossingAngle(150e-6) #used only in option 2
 
-
    # Neutrino vertex generation range in z:
    # Tolerance for neutrino vertex generation range. Mostly to account for tilt in geometry alignment. Take difference in z coordinate of vertical fibres of around 0.5 cm over the fibre length, 39 cm. Assume maximum difference in z is 1 m * 0.5/39.
    tolerance_vtx_z = 1*u.m * 0.5/39

--- a/shipLHC/run_simSND.py
+++ b/shipLHC/run_simSND.py
@@ -193,8 +193,18 @@ if simEngine=="Genie":
    Geniegen.SetGenerationOption(options.genie - 1) # 0 standard, 1 FLUKA,2 Pythia
    Geniegen.Init(inputFile,options.firstEvent)
    Geniegen.SetCrossingAngle(150e-6) #used only in option 2
-   Geniegen.SetPositions(snd_geo.EmulsionDet.zC-480*u.m, snd_geo.EmulsionDet.zC-snd_geo.EmulsionDet.zdim/2,snd_geo.EmulsionDet.zC+snd_geo.EmulsionDet.zdim/2)
-   #Geniegen.SetPositions(snd_geo.EmulsionDet.zC+60*u.cm, snd_geo.EmulsionDet.zC-snd_geo.EmulsionDet.zdim/2,snd_geo.EmulsionDet.zC+snd_geo.EmulsionDet.zdim/2) #FLUKA scoring position
+
+
+   # Neutrino vertex generation range in z:
+   # Tolerance for neutrino vertex generation range. Mostly to account for tilt in geometry alignment. Take difference in z coordinate of vertical fibres of around 0.5 cm over the fibre length, 39 cm. Assume maximum difference in z is 1 m * 0.5/39.
+   tolerance_vtx_z = 1*u.m * 0.5/39
+   # From first veto bar
+   neutrino_vtx_start_z = snd_geo.MuFilter.Veto1Dy - snd_geo.MuFilter.VetoBarZ/2. - tolerance_vtx_z
+   # To last Scifi plane
+   neutrino_vtx_end_z = snd_geo.Scifi.Ypos4 + snd_geo.Scifi.zdim/2. + tolerance_vtx_z
+
+   Geniegen.SetPositions(-480*u.m, neutrino_vtx_start_z, neutrino_vtx_end_z)
+
    Geniegen.SetDeltaE_Matching_FLUKAGenie(10.) #energy range for the search of a GENIE interaction with similar energy of FLUKA neutrino
    primGen.AddGenerator(Geniegen)
    options.nEvents = min(options.nEvents,Geniegen.GetNevents())


### PR DESCRIPTION
Z range for generating neutrino interaction vertices was offset by around 12 cm. Now generating neutrinos from the start of the first veto bar to the end of the last Scifi plane, with some tolerance for the detector tilt.

Neutrino vertex distribution before fix:
![neutrino_vertices_zx](https://user-images.githubusercontent.com/11177614/157195790-8bbe760f-cd1c-48e5-8ec7-dcac22b2cb4d.png)

Neutrino vertex distribution after fix:
![neutrino_vtx_zx_fixed](https://user-images.githubusercontent.com/11177614/157195840-4393c289-5507-4317-ba72-2f703fee0b58.png)

Also removed the obsolete geometry variables: `EmulsionDet/zC` and `EmulsionDet/startpos`.