### PR TITLE
Updating README with ubuntu 20 CVMFS comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,13 @@ eval alienv load sndsw/latest
 
 If you modify `sndsw`, simply repeat step 4 from `sndsw`'s parent directory.
 
+Note for Ubuntu 20.04: currently there is a version (March 2022) of CVMFS built with Ubuntu 20.04. However, standard ubuntu 20.04 still have python2 has default, while we moved to python3.
+So, it is needed to do 
+```bash
+sudo apt-get install python-is-python3
+```
+
+Then, the above procedure works
 ## On systems without access to CVMFS
 
 Commands are similar to the previous case, but without access to CVMFS you need to build the required packages from source.


### PR DESCRIPTION
Dear SNDSW users,

Together with @siilieva, we tested the CVMFS setup with Ubuntu 20.04.

It works, with the same procedure described in the README for CENTOS7.

Only warning, since we moved to python3: we should first install python-is-python3 package, since Ubuntu20 still has Python2.7 as default system.

We also found some missing/not working packages, so we updated the list. Being shared with FairShip, as usual, I opened a pull request directly there (https://github.com/ShipSoft/FairShip/pull/400).

Best wishes,
Antonio