### PR TITLE
Add graphviz installation

### DIFF
--- a/.github/workflows/doxygen-gh-pages.yml
+++ b/.github/workflows/doxygen-gh-pages.yml
@@ -10,6 +10,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
+      - name: Install Graphviz
+        run: sudo apt-get install graphviz -y
+        shell: bash
       - uses: DenverCoder1/doxygen-github-pages-action@v1.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Dear all,
You may notice that in our new Doxygen page the inheritance graphs are broken. For example at the start of EmulsionDet class:

https://snd-lhc.github.io/sndsw/classEmulsionDet.html

The reason is, that the GitHub Actions terminal does not recognize the required "dot" command.

Checking the github repository, the suggested solution is to install the graphviz package required for graphs. See here:
https://github.com/DenverCoder1/doxygen-github-pages-action/issues/14.

This pull request applies that.
Best regards,
Antonio Iuliano