### PR TITLE
Temporary fix for muon DIS simulations

### DIFF
--- a/shipLHC/run_simSND.py
+++ b/shipLHC/run_simSND.py
@@ -291,7 +291,7 @@ if inactivateMuonProcesses :
  mygMC = ROOT.TGeant4.GetMC()
  mygMC.ProcessGeantCommand("/process/inactivate muPairProd")
  mygMC.ProcessGeantCommand("/process/inactivate muBrems")
- mygMC.ProcessGeantCommand("/process/inactivate muIoni")
+ #mygMC.ProcessGeantCommand("/process/inactivate muIoni")  Temporary fix for DIS Simulations (incoming and outgoing muon hits)
  mygMC.ProcessGeantCommand("/process/inactivate muonNuclear")
  mygMC.ProcessGeantCommand("/particle/select mu+")
  mygMC.ProcessGeantCommand("/particle/process/dump")


### PR DESCRIPTION
By commenting this line, Ionization processes will be enabled for muons in DIS simulation. In particular, this will let incoming muon and outgoing muon produce hits in the electronic detectors, as expected. (Temporary fix)