### PR TITLE
a fix in cppDigi and get station for MuFilterHit

### DIFF
--- a/shipLHC/MuFilterHit.h
+++ b/shipLHC/MuFilterHit.h
@@ -37,7 +37,7 @@ class MuFilterHit : public SndlhcHit
     bool isMasked(Int_t i) const {return fMasked[i];}
     void SetMasked(Int_t i) {fMasked[i]=kTRUE;}
     int GetSystem(){return floor(fDetectorID/10000);}
-    int GetStation(){return floor(fDetectorID/1000)+1;}
+    int GetStation(){return int(fDetectorID/1000)%10+1;}
     bool isVertical();
     bool isShort(Int_t);
   private:

--- a/shipLHC/MuFilterHit.h
+++ b/shipLHC/MuFilterHit.h
@@ -37,7 +37,7 @@ class MuFilterHit : public SndlhcHit
     bool isMasked(Int_t i) const {return fMasked[i];}
     void SetMasked(Int_t i) {fMasked[i]=kTRUE;}
     int GetSystem(){return floor(fDetectorID/10000);}
-    int GetStation(){return int(fDetectorID/1000)%10+1;}
+    int GetPlane(){return int(fDetectorID/1000)%10;}
     bool isVertical();
     bool isShort(Int_t);
   private:

--- a/shipLHC/MuFilterHit.h
+++ b/shipLHC/MuFilterHit.h
@@ -37,6 +37,7 @@ class MuFilterHit : public SndlhcHit
     bool isMasked(Int_t i) const {return fMasked[i];}
     void SetMasked(Int_t i) {fMasked[i]=kTRUE;}
     int GetSystem(){return floor(fDetectorID/10000);}
+    int GetStation(){return floor(fDetectorID/1000)+1;}
     bool isVertical();
     bool isShort(Int_t);
   private:

--- a/sndFairTasks/DigiTaskSND.cxx
+++ b/sndFairTasks/DigiTaskSND.cxx
@@ -61,7 +61,12 @@ InitStatus DigiTaskSND::Init()
     siPMFibres = scifi->GetFibresMap();
 
     // Get event header
+    // Try classic FairRoot approach first
     fMCEventHeader = static_cast<FairMCEventHeader*> (ioman->GetObject("MCEventHeader."));	
+    // .. with a safety net for trailing dots mischief
+    if ( fMCEventHeader == nullptr ) {
+       fMCEventHeader = static_cast<FairMCEventHeader*>(gROOT->FindObjectAny("MCEventHeader."));
+    }
     // Get input MC points
     fScifiPointArray = static_cast<TClonesArray*>(ioman->GetObject("ScifiPoint"));
     fvetoPointArray = static_cast<TClonesArray*>(ioman->GetObject("vetoPoint"));
@@ -79,7 +84,7 @@ InitStatus DigiTaskSND::Init()
     ioman->Register("EmulsionDetPoint", "EmulsionDetPoints", fvetoPointArray, kTRUE);
     ioman->Register("ScifiPoint", "ScifiPoints", fScifiPointArray, kTRUE);
     ioman->Register("MuFilterPoint", "MuFilterPoints", fMuFilterPointArray, kTRUE);
-    ioman->Register("MCEventHeader.", "MCEventHeader", fMCEventHeader, kTRUE);
+    ioman->RegisterAny("MCEventHeader.", fMCEventHeader, kTRUE);
  
     // Event header
     fEventHeader = new FairEventHeader();


### PR DESCRIPTION
I noticed a bug in the cpp digitization related to "MCEventHeader." branch after the switch to newest ROOT 6.26. It has to do with the dot in the branch name and the simplest fix is introduced. Also, added a getStation method for MuFi hits, sndsw has the same for SciFi hits [link](https://github.com/SND-LHC/sndsw/blob/master/shipLHC/sndScifiHit.h#L28)