### PR TITLE
Filling scheme data into SNDLHCEventHeader

### DIFF
--- a/python/SndlhcDigi.py
+++ b/python/SndlhcDigi.py
@@ -19,7 +19,7 @@ class SndlhcDigi:
         self.sTree = self.fn.cbmsim
 
         # event header
-        self.header  = ROOT.FairEventHeader()
+        self.header  = ROOT.SNDLHCEventHeader()
         self.eventHeader  = self.sTree.Branch("EventHeader",self.header,32000,1)
         #scifi
         self.digiScifi   = ROOT.TClonesArray("sndScifiHit")
@@ -49,7 +49,8 @@ class SndlhcDigi:
     def digitize(self):
 
         self.header.SetRunId( self.sTree.MCEventHeader.GetRunID() )
-        self.header.SetMCEntryNumber( self.sTree.MCEventHeader.GetEventID() )  # counts from 1
+        self.header.SetEventNumber( self.sTree.MCEventHeader.GetEventID() )  # counts from 1
+        self.header.SetBunchType(101);
         self.eventHeader.Fill()
         self.digiScifi.Delete()
         self.digiScifi2MCPoints.Delete()

--- a/shipLHC/SNDLHCEventHeader.cxx
+++ b/shipLHC/SNDLHCEventHeader.cxx
@@ -7,6 +7,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <bitset>
 
 using namespace std;
 
@@ -36,16 +37,18 @@ SNDLHCEventHeader::SNDLHCEventHeader()
   , fFillNumber(0)
   , fAccMode(0)
   , fBeamMode(0)
+  , fBunchType(0)
 {}
 // -------------------------------------------------------------------------
 
 // -----   Standard constructor   ------------------------------------------
-SNDLHCEventHeader::SNDLHCEventHeader(Int_t runN, uint64_t evtNumber, int64_t timestamp, uint64_t flags)
+SNDLHCEventHeader::SNDLHCEventHeader(Int_t runN, uint64_t evtNumber, int64_t timestamp, uint64_t flags, uint16_t bunchType)
 {
    SetRunId(runN);
    SetEventTime(timestamp);
    SetEventNumber(evtNumber);
    SetFlags(flags);
+   SetBunchType(bunchType);
 }
 
 // -------------------------------------------------------------------------
@@ -129,6 +132,29 @@ vector<string> SNDLHCEventHeader::GetPassedAdvNFCriteria()
   return passed;
 }
 
+bool SNDLHCEventHeader::isB1()
+{
+   bitset<4> bt = fBunchType;
+   return bt[3]==1;
+}
+
+bool SNDLHCEventHeader::isB2()
+{
+   bitset<4> bt = fBunchType;
+   return bt[2]==1;
+}
+
+bool SNDLHCEventHeader::isIP1()
+{
+   bitset<4> bt = fBunchType;
+   return bt[1]==1;
+}
+
+bool SNDLHCEventHeader::isIP2()
+{
+   bitset<4> bt = fBunchType;
+   return bt[0]==1;
+}
 // -----   Public method Print   -------------------------------------------
 void SNDLHCEventHeader::Print(const Option_t* opt) const
 {

--- a/shipLHC/SNDLHCEventHeader.cxx
+++ b/shipLHC/SNDLHCEventHeader.cxx
@@ -7,7 +7,6 @@
 #include <map>
 #include <string>
 #include <vector>
-#include <bitset>
 
 using namespace std;
 
@@ -37,12 +36,12 @@ SNDLHCEventHeader::SNDLHCEventHeader()
   , fFillNumber(0)
   , fAccMode(0)
   , fBeamMode(0)
-  , fBunchType(0)
+  , fBunchType(-1)
 {}
 // -------------------------------------------------------------------------
 
 // -----   Standard constructor   ------------------------------------------
-SNDLHCEventHeader::SNDLHCEventHeader(Int_t runN, uint64_t evtNumber, int64_t timestamp, uint64_t flags, uint16_t bunchType)
+SNDLHCEventHeader::SNDLHCEventHeader(Int_t runN, uint64_t evtNumber, int64_t timestamp, uint64_t flags, int16_t bunchType)
 {
    SetRunId(runN);
    SetEventTime(timestamp);
@@ -132,28 +131,50 @@ vector<string> SNDLHCEventHeader::GetPassedAdvNFCriteria()
   return passed;
 }
 
-bool SNDLHCEventHeader::isB1()
+bool SNDLHCEventHeader::isIP2()
 {
-   bitset<4> bt = fBunchType;
-   return bt[3]==1;
-}
-
-bool SNDLHCEventHeader::isB2()
-{
-   bitset<4> bt = fBunchType;
-   return bt[2]==1;
+   return (fBunchType/1000)%10==1;
 }
 
 bool SNDLHCEventHeader::isIP1()
 {
-   bitset<4> bt = fBunchType;
-   return bt[1]==1;
+   return (fBunchType/100)%10==1;
 }
 
-bool SNDLHCEventHeader::isIP2()
+bool SNDLHCEventHeader::isB2()
 {
-   bitset<4> bt = fBunchType;
-   return bt[0]==1;
+   return (fBunchType/10)%10==1;
+}
+
+bool SNDLHCEventHeader::isB1()
+{
+   return fBunchType%10==1;
+}
+
+bool SNDLHCEventHeader::isB1Only()
+{
+   /* b1 and not IP1 and not b2 */
+   return isB1() && !isIP1() && !isB2();
+}
+
+bool SNDLHCEventHeader::isB2noB1()
+{
+   /* b2 and not b1 */
+   return isB2() && !isB1();
+}
+
+bool SNDLHCEventHeader::isNoBeam()
+{
+   /* not b1 and not b2
+      Also, its return must be False in case
+      no filling scheme data is available (fBunchType=-1) */
+   return fBunchType%10==0 && (fBunchType/10)%10==0;
+}
+
+bool SNDLHCEventHeader::isNoFSData()
+{
+   /* no filling scheme data available (fBunchType=-1) */
+   return fBunchType%10==-1;
 }
 // -----   Public method Print   -------------------------------------------
 void SNDLHCEventHeader::Print(const Option_t* opt) const

--- a/shipLHC/SNDLHCEventHeader.h
+++ b/shipLHC/SNDLHCEventHeader.h
@@ -1,5 +1,5 @@
 #ifndef SNDLHCEVENTHEADER_H
-#define SNDLHCEVENTHEADER_H 1
+#define SNDLHCEVENTHEADER_H 2
 
 #include <TNamed.h>
 #include "SNDLHCEventHeaderConst.h"
@@ -23,7 +23,7 @@ class SNDLHCEventHeader : public TNamed
     SNDLHCEventHeader();
 
     /** Constructor with arguments **/
-    SNDLHCEventHeader(Int_t runN, uint64_t evtNumber, int64_t timestamp, uint64_t flags);
+    SNDLHCEventHeader(Int_t runN, uint64_t evtNumber, int64_t timestamp, uint64_t flags, uint16_t bunchType);
 
     /** Destructor **/
     virtual ~SNDLHCEventHeader();
@@ -35,6 +35,7 @@ class SNDLHCEventHeader : public TNamed
     void SetEventNumber(int id) { fEventNumber = id; }
     void SetUTCtimestamp(int64_t UTCtstamp) { fUTCtimestamp = UTCtstamp; };
     void SetFlags(uint64_t flags);
+    void SetBunchType(uint16_t bunchType) { fBunchType = bunchType; };
 
     /** Getters **/
     uint64_t GetRunId() { return fRunId; }
@@ -50,7 +51,12 @@ class SNDLHCEventHeader : public TNamed
     map<string, bool> GetAdvNoiseFilters();
     vector<string> GetPassedFastNFCriteria();
     vector<string> GetPassedAdvNFCriteria();
-
+    uint16_t GetBunchType() { return fBunchType; }
+    /** Functions to check bunch xing type **/
+    bool isB1();
+    bool isB2();
+    bool isIP1();
+    bool isIP2();
     /** Output to screen **/
     virtual void Print(const Option_t* opt) const;
 
@@ -64,12 +70,13 @@ class SNDLHCEventHeader : public TNamed
     uint16_t fFillNumber;
     int fAccMode; // enum class
     int fBeamMode; // enum class
+    uint16_t fBunchType;
     
     /** Copy constructor **/
     SNDLHCEventHeader(const SNDLHCEventHeader& eventHeader);
     SNDLHCEventHeader operator=(const SNDLHCEventHeader& eventHeader);
 
-    ClassDef(SNDLHCEventHeader,1)
+    ClassDef(SNDLHCEventHeader,2)
 
 };
 

--- a/shipLHC/SNDLHCEventHeader.h
+++ b/shipLHC/SNDLHCEventHeader.h
@@ -23,7 +23,7 @@ class SNDLHCEventHeader : public TNamed
     SNDLHCEventHeader();
 
     /** Constructor with arguments **/
-    SNDLHCEventHeader(Int_t runN, uint64_t evtNumber, int64_t timestamp, uint64_t flags, uint16_t bunchType);
+    SNDLHCEventHeader(Int_t runN, uint64_t evtNumber, int64_t timestamp, uint64_t flags, int16_t bunchType);
 
     /** Destructor **/
     virtual ~SNDLHCEventHeader();
@@ -35,7 +35,7 @@ class SNDLHCEventHeader : public TNamed
     void SetEventNumber(int id) { fEventNumber = id; }
     void SetUTCtimestamp(int64_t UTCtstamp) { fUTCtimestamp = UTCtstamp; };
     void SetFlags(uint64_t flags);
-    void SetBunchType(uint16_t bunchType) { fBunchType = bunchType; };
+    void SetBunchType(int16_t bunchType) { fBunchType = bunchType; };
 
     /** Getters **/
     uint64_t GetRunId() { return fRunId; }
@@ -51,12 +51,16 @@ class SNDLHCEventHeader : public TNamed
     map<string, bool> GetAdvNoiseFilters();
     vector<string> GetPassedFastNFCriteria();
     vector<string> GetPassedAdvNFCriteria();
-    uint16_t GetBunchType() { return fBunchType; }
+    int16_t GetBunchType() { return fBunchType; }
     /** Functions to check bunch xing type **/
     bool isB1();
     bool isB2();
     bool isIP1();
     bool isIP2();
+    bool isB1Only();
+    bool isB2noB1();
+    bool isNoBeam();
+    bool isNoFSData();
     /** Output to screen **/
     virtual void Print(const Option_t* opt) const;
 
@@ -70,7 +74,8 @@ class SNDLHCEventHeader : public TNamed
     uint16_t fFillNumber;
     int fAccMode; // enum class
     int fBeamMode; // enum class
-    uint16_t fBunchType;
+    /* fBunchType = IP2*1000+IP1*100+B2*10+B1 */
+    int16_t fBunchType;
     
     /** Copy constructor **/
     SNDLHCEventHeader(const SNDLHCEventHeader& eventHeader);

--- a/shipLHC/rawData/ConvRawData.py
+++ b/shipLHC/rawData/ConvRawData.py
@@ -4,6 +4,7 @@ import ROOT,os,sys
 import boardMappingParser
 import csv
 import time
+from rootpyPickler import Unpickler
 
 # raw data from Ettore: https://cernbox.cern.ch/index.php/s/Ten7ilKuD3qdnM2 
 
@@ -36,6 +37,40 @@ class ConvRawDataPY(ROOT.FairTask):
          path    = options.path+'run_'+ runNr+'/'
          inFile   = 'data_'+part+'.root'
          self.outFile = ROOT.TMemFile('monitorRawData', 'recreate')
+
+# get filling scheme per run
+      try:
+         #FIXME get path to FSdict file
+         #fg  = ROOT.TFile.Open(options.server+options.path+'FSdict.root')
+         fg = ROOT.TFile.Open("/eos/experiment/sndlhc/convertedData/commissioning/TI18/FSdict.root")
+         pkl = Unpickler(fg)
+         FSdict = pkl.load('FSdict')
+         fg.Close()
+
+         if options.runNumber in FSdict: self.fsdict = FSdict[options.runNumber]
+         else:  self.fsdict = False
+      except:
+         print('continue without knowing filling scheme',options.server+options.path)
+         self.fsdict = False  
+      
+      # put the run's FS in format to be passed to FairTasks as input
+      if self.fsdict:
+         self.FSmap = ROOT.TMap()
+         for bunchNumber in range (0, 3564):
+             nb1 = (3564 + bunchNumber - self.fsdict['phaseShift1'])%3564
+             nb2 = (3564 + bunchNumber - self.fsdict['phaseShift1']- self.fsdict['phaseShift2'])%3564
+             b1 = nb1 in self.fsdict['B1']
+             b2 = nb2 in self.fsdict['B2']
+             IP1 = False
+             IP2 = False
+             if b1:
+                IP1 =  self.fsdict['B1'][nb1]['IP1']
+             if b2:
+                IP2 =  self.fsdict['B2'][nb2]['IP2']
+             if b1 and not IP1 and not b2: B1only = True
+             if b2 and not b1: B2noB1 = True
+             if not b1 and not b2: noBeam = True
+             self.FSmap.Add(ROOT.TObjString(str(bunchNumber)), ROOT.TObjString(str(int(b1))+str(int(b2))+str(int(IP1))+str(int(IP2))))
 
       self.run     = ROOT.FairRunAna()
       self.ioman = ROOT.FairRootManager.Instance()
@@ -71,6 +106,7 @@ class ConvRawDataPY(ROOT.FairTask):
       ioman.RegisterInputObject('saturationLimit', ROOT.TObjString(str(options.saturationLimit)))
       ioman.RegisterInputObject('local', ROOT.TObjString(str(int(local))))
       ioman.RegisterInputObject('newFormat', ROOT.TObjString(str(int(self.newFormat))))
+      ioman.RegisterInputObject('FSmap', self.FSmap)
       self.options = options
       
   # Initialize logger: set severity and verbosity
@@ -374,6 +410,7 @@ class ConvRawDataPY(ROOT.FairTask):
      self.header.SetEventNumber(event.evt_number) #   for new event header
      self.header.SetFlags(event.evt_flags)
      self.header.SetRunId( self.options.runNumber )
+     self.header.SetBunchType(int(str(self.FSmap.GetValue(str( int(event.evt_timestamp%(4*3564)/4+0.5))))))
 
      indexSciFi=0
      self.digiSciFi.Delete()

--- a/shipLHC/run_digiSND.py
+++ b/shipLHC/run_digiSND.py
@@ -79,6 +79,9 @@ if options.FairTask_digi:
   ioman = ROOT.FairRootManager.Instance()
   ioman.RegisterInputObject('Scifi', snd_geo.modules['Scifi'])
   ioman.RegisterInputObject('MuFilter', snd_geo.modules['MuFilter'])
+  # Don't use FairRoot's default event header settings
+  run.SetEventHeaderPersistence(False)
+  
   # Set input
   fileSource = ROOT.FairFileSource(options.inputFile)
   run.SetSource(fileSource)

--- a/shipLHC/scripts/Monitor.py
+++ b/shipLHC/scripts/Monitor.py
@@ -296,7 +296,7 @@ class Monitoring():
       self.xing = {'all':True,'B1only':False,'B2noB1':False,'noBeam':False}
       if self.fsdict:
              T   = self.eventTree.EventHeader.GetEventTime()
-             bunchNumber = int(T%(4*3564)/4+0.5)
+             bunchNumber = int((T%(4*3564))/4)
              nb1 = (3564 + bunchNumber - self.fsdict['phaseShift1'])%3564
              nb2 = (3564 + bunchNumber - self.fsdict['phaseShift1']- self.fsdict['phaseShift2'])%3564
              b1 = nb1 in self.fsdict['B1']

--- a/sndFairTasks/ConvRawData.cxx
+++ b/sndFairTasks/ConvRawData.cxx
@@ -80,6 +80,8 @@ InitStatus ConvRawData::Init()
     TObjString* saturationLimit_obj = dynamic_cast<TObjString*>(ioman->GetObject("saturationLimit"));
     TObjString* newFormat_obj = dynamic_cast<TObjString*>(ioman->GetObject("newFormat"));
     TObjString* local_obj = dynamic_cast<TObjString*>(ioman->GetObject("local"));
+    // TMap containing the filling scheme per given run
+    FSmap = static_cast<TMap*>(ioman->GetObject("FSmap"));    
     // Input raw data file is read from the FairRootManager
     // This allows to have it in custom format, e.g. have arbitary names of TTrees
     TFile* f0 = dynamic_cast<TFile*>(ioman->GetObject("rawData"));
@@ -464,7 +466,8 @@ void ConvRawData::Process1()
   int nSiPMs{}, nSides{}, direction{}, detID{}, sipm_number{}, chan{}, orientation{}, sipmLocal{};
   int sipmID{};
   double test{};
-  //TStopwatch timer;     
+  int64_t eventTime{};
+  //TStopwatch timer;
   
   tE = high_resolution_clock::now();
   //timer.Start();
@@ -479,14 +482,17 @@ void ConvRawData::Process1()
   
   fSNDLHCEventHeader->SetFlags(fEventTree->GetLeaf("evtFlags")->GetValue());
   fSNDLHCEventHeader->SetRunId(frunNumber);
-  fSNDLHCEventHeader->SetEventTime(fEventTree->GetLeaf("evtTimestamp")->GetValue());
-  fSNDLHCEventHeader->SetUTCtimestamp(fEventTree->GetLeaf("evtTimestamp")->GetValue()*6.23768*1e-9 + runStartUTC);
+  eventTime = fEventTree->GetLeaf("evtTimestamp")->GetValue();
+  fSNDLHCEventHeader->SetEventTime(eventTime);
+  fSNDLHCEventHeader->SetUTCtimestamp(eventTime*6.23768*1e-9 + runStartUTC);
   fSNDLHCEventHeader->SetEventNumber(fEventTree->GetLeaf("evtNumber")->GetValue());
-
+  // Fill filling scheme data into the event header
+  fSNDLHCEventHeader->SetBunchType(stoi(((TObjString*)FSmap->GetValue((Form("%d", int(eventTime%(4*3564)/4+0.5)))))->GetString().Data()));
+  
   LOG (info) << "evtNumber per run "
              << fEventTree->GetLeaf("evtNumber")->GetValue()
              << " evtNumber per partition: " << eventNumber
-             << " timestamp: " << fEventTree->GetLeaf("evtTimestamp")->GetValue();
+             << " timestamp: " << eventTime;
   // Delete pointer map elements
   for (auto it : digiSciFiStore)
   {

--- a/sndFairTasks/ConvRawData.cxx
+++ b/sndFairTasks/ConvRawData.cxx
@@ -487,7 +487,10 @@ void ConvRawData::Process1()
   fSNDLHCEventHeader->SetUTCtimestamp(eventTime*6.23768*1e-9 + runStartUTC);
   fSNDLHCEventHeader->SetEventNumber(fEventTree->GetLeaf("evtNumber")->GetValue());
   // Fill filling scheme data into the event header
-  fSNDLHCEventHeader->SetBunchType(stoi(((TObjString*)FSmap->GetValue((Form("%d", int(eventTime%(4*3564)/4+0.5)))))->GetString().Data()));
+  if (FSmap->GetEntries()>1)
+      fSNDLHCEventHeader->SetBunchType(stoi(((TObjString*)FSmap->GetValue(Form("%d", (eventTime%(4*3564))/4)))->GetString().Data()));
+  else
+      fSNDLHCEventHeader->SetBunchType(stoi(((TObjString*)FSmap->GetValue("0"))->GetString().Data())); 
   
   LOG (info) << "evtNumber per run "
              << fEventTree->GetLeaf("evtNumber")->GetValue()

--- a/sndFairTasks/ConvRawData.h
+++ b/sndFairTasks/ConvRawData.h
@@ -3,6 +3,7 @@
 
 #include <TClonesArray.h>
 #include <TFile.h>
+#include <TMap.h>
 #include "FairTask.h"           // for FairTask, InitStatus
 #include "FairEventHeader.h"    // for FairEventHeader
 #include "SNDLHCEventHeader.h"  // for EventHeader
@@ -95,6 +96,8 @@ class ConvRawData : public FairTask
       int eventNumber;
       double chi2Max, saturationLimit;
       double runStartUTC;
+      /** Filling scheme per run **/
+      TMap* FSmap;
     
       /** Output data **/
       SNDLHCEventHeader* fSNDLHCEventHeader;
@@ -105,6 +108,6 @@ class ConvRawData : public FairTask
       ConvRawData(const ConvRawData&);
       ConvRawData& operator=(const ConvRawData&);
 
-      ClassDef(ConvRawData, 2);
+      ClassDef(ConvRawData, 3);
 };
 #endif /* CONVRAWDATA_H_ */

--- a/sndFairTasks/DigiTaskSND.cxx
+++ b/sndFairTasks/DigiTaskSND.cxx
@@ -14,7 +14,6 @@
  #include <iostream>                 // for operator<<, basic_ostream, endl
  #include <algorithm>                // std::sort
  #include <vector>                   // std::vector
- #include "FairEventHeader.h"        // for FairEventHeader
  #include "FairMCEventHeader.h"      // for FairMCEventHeader
  #include "FairLink.h"               // for FairLink
  #include "FairRunSim.h"             // for FairRunSim
@@ -84,10 +83,9 @@ InitStatus DigiTaskSND::Init()
     ioman->Register("EmulsionDetPoint", "EmulsionDetPoints", fvetoPointArray, kTRUE);
     ioman->Register("ScifiPoint", "ScifiPoints", fScifiPointArray, kTRUE);
     ioman->Register("MuFilterPoint", "MuFilterPoints", fMuFilterPointArray, kTRUE);
-    ioman->RegisterAny("MCEventHeader.", fMCEventHeader, kTRUE);
  
     // Event header
-    fEventHeader = new FairEventHeader();
+    fEventHeader = new SNDLHCEventHeader();
     ioman->Register("EventHeader", "sndEventHeader", fEventHeader, kTRUE);
 
     // Create and register output array - for SciFi and MuFilter
@@ -121,9 +119,10 @@ void DigiTaskSND::Exec(Option_t* /*opt*/)
     fMuFilterDigiHitArray->Delete();
     fMuFilterHit2MCPointsArray->Delete();
 
-    // Get event header
+    // Set event header
     fEventHeader->SetRunId(fMCEventHeader->GetRunID());
-    fEventHeader->SetMCEntryNumber(fMCEventHeader->GetEventID());
+    fEventHeader->SetEventNumber(fMCEventHeader->GetEventID());
+    fEventHeader->SetBunchType(101);
 
     // Digitize MC points if any
     if (fMuFilterPointArray) digitizeMuFilter();

--- a/sndFairTasks/DigiTaskSND.h
+++ b/sndFairTasks/DigiTaskSND.h
@@ -12,9 +12,10 @@
 #include <RtypesCore.h>         // for Double_t, Int_t, Option_t
 #include <TClonesArray.h> 
 #include "FairTask.h"           // for FairTask, InitStatus
-#include "FairEventHeader.h"    // for FairEventHeader
+//#include "FairEventHeader.h"    // for FairEventHeader
 #include "FairMCEventHeader.h"  // for FairMCEventHeader
 #include "Scifi.h"              // for Scifi detector
+#include "SNDLHCEventHeader.h"  // for EventHeader
 class TBuffer;
 class TClass;
 class TClonesArray;
@@ -55,7 +56,7 @@ class DigiTaskSND : public FairTask
     TClonesArray* fScifiPointArray;
     TClonesArray* fScifiClusterArray;
     // Output
-    FairEventHeader* fEventHeader;
+    SNDLHCEventHeader* fEventHeader;
     TClonesArray* fMuFilterDigiHitArray; // hit class (digitized!)
     TClonesArray* fScifiDigiHitArray;
     TClonesArray* fMuFilterHit2MCPointsArray; // link to MC truth
@@ -72,7 +73,7 @@ class DigiTaskSND : public FairTask
     Float_t MufiLargeThreshold;
     Float_t MufiSmallThreshold;
 
-    ClassDef(DigiTaskSND, 1);
+    ClassDef(DigiTaskSND, 2);
 };
 
 #endif /* DIGITASKSND_H_ */


### PR DESCRIPTION
- MC productions will use the SNDLHCEventHeader now; only IP1, B1 bunch types in the MC event header though
- if there is no FSdict entry for a given runN, bunch type is set to -1
- the bunch N formula in Monitor.py is changed
ps. tested ok for both py and cpp converted raw data, comparing with BunchStructure.root monitoring plots. Also works for MC py and cpp digitized data - no errors encountered