### PR TITLE
Evt header in shipLHC dict

### DIFF
--- a/python/SndlhcDigi.py
+++ b/python/SndlhcDigi.py
@@ -20,7 +20,7 @@ class SndlhcDigi:
 
         # event header
         self.header  = ROOT.SNDLHCEventHeader()
-        self.eventHeader  = self.sTree.Branch("EventHeader",self.header,32000,1)
+        self.eventHeader  = self.sTree.Branch("EventHeader.",self.header,32000,1)
         #scifi
         self.digiScifi   = ROOT.TClonesArray("sndScifiHit")
         self.digiScifiBranch   = self.sTree.Branch("Digi_ScifiHits",self.digiScifi,32000,1)

--- a/shipLHC/scripts/2dEventDisplay.py
+++ b/shipLHC/scripts/2dEventDisplay.py
@@ -119,6 +119,8 @@ HT_tasks['muon_reco_task_DS'].SetTrackingCase('passing_mu_DS')
 HT_tasks['muon_reco_task_nuInt'].SetTrackingCase('nu_interaction_products')
 
 run.Init()
+OT = sink.GetOutTree()
+OT.Reco_MuonTracks = ROOT.TObjArray(10)
 eventTree = ioman.GetInTree()
 # backward compatbility for early converted events
 eventTree.GetEvent(0)
@@ -238,7 +240,7 @@ def loopEvents(start=0,save=False,goodEvents=False,withTrack=-1,withHoughTrack=-
     else: rc = event.GetEvent(start[N])
     if goodEvents and not goodEvent(event): continue
     nHoughtracks = 0
-    OT.Reco_MuonTracks = ROOT.TObjArray(10)
+    OT.Reco_MuonTracks.Delete()
     if withHoughTrack > 0:
        rc = source.GetInTree().GetEvent(N)
        # Delete SndlhcMuonReco kalman tracks container
@@ -261,7 +263,7 @@ def loopEvents(start=0,save=False,goodEvents=False,withTrack=-1,withHoughTrack=-
        if len(uniqueTracks)<nTracks:
           OT.Reco_MuonTracks.Delete()
        nHoughtracks = OT.Reco_MuonTracks.GetEntries()
-       print('number of tracks by pattern recognition:', nHoughtracks)
+       if nHoughtracks>0: print('number of tracks by pattern recognition:', nHoughtracks)
 
     if withTrack > 0:
           # Delete SndlhcTracking fitted tracks container
@@ -276,7 +278,7 @@ def loopEvents(start=0,save=False,goodEvents=False,withTrack=-1,withHoughTrack=-
           for trk in trackTask.fittedTracks:
               OT.Reco_MuonTracks.Add(trk)
           ntracks = len(OT.Reco_MuonTracks) - nHoughtracks
-          print('number of tracks by KF-based tracking:', ntracks)
+          if ntracks>0: print('number of tracks by KF-based tracking:', ntracks)
     nAlltracks = len(OT.Reco_MuonTracks)
     if nAlltracks<nTracks: continue
 

--- a/shipLHC/scripts/2dEventDisplay.py
+++ b/shipLHC/scripts/2dEventDisplay.py
@@ -287,7 +287,7 @@ def loopEvents(start=0,save=False,goodEvents=False,withTrack=-1,withHoughTrack=-
            mom.Print()
            pos.Print()
     T,dT = 0,0
-    if event.FindBranch("EventHeader"):
+    if event.FindBranch("EventHeader") or event.FindBranch("EventHeader."):
        T = event.EventHeader.GetEventTime()
        runId = eventTree.EventHeader.GetRunId()
        if Tprev >0: dT = T-Tprev

--- a/shipLHC/shipLHCLinkDef.h
+++ b/shipLHC/shipLHCLinkDef.h
@@ -16,7 +16,7 @@
 #pragma link C++ class MuFilterHit+;
 #pragma link C++ class sndScifiHit+;
 #pragma link C++ class sndCluster;
-#pragma link C++ class SNDLHCEventHeader;
+#pragma link C++ class SNDLHCEventHeader+;
 #pragma link C++ class sndRecoTrack+;
 
 #endif

--- a/sndFairTasks/ConvRawData.cxx
+++ b/sndFairTasks/ConvRawData.cxx
@@ -123,7 +123,7 @@ InitStatus ConvRawData::Init()
         fEventTree = (TTree*)f0->Get("data");
         // use sndlhc eventHeader class
         fSNDLHCEventHeader = new SNDLHCEventHeader();
-        ioman->Register("EventHeader", "sndEventHeader", fSNDLHCEventHeader, kTRUE);        
+        ioman->Register("EventHeader.", "sndEventHeader", fSNDLHCEventHeader, kTRUE);        
     }
      
     fDigiSciFi    = new TClonesArray("sndScifiHit");
@@ -785,6 +785,7 @@ void ConvRawData::StartTimeofRun(string Path)
      }
   }
   runStartUTC = timegm(&tm);
+
 }
 /** Board mapping for Scifi and MuFilter **/
 void ConvRawData::DetMapping(string Path)

--- a/sndFairTasks/DigiTaskSND.cxx
+++ b/sndFairTasks/DigiTaskSND.cxx
@@ -86,7 +86,7 @@ InitStatus DigiTaskSND::Init()
  
     // Event header
     fEventHeader = new SNDLHCEventHeader();
-    ioman->Register("EventHeader", "sndEventHeader", fEventHeader, kTRUE);
+    ioman->Register("EventHeader.", "sndEventHeader", fEventHeader, kTRUE);
 
     // Create and register output array - for SciFi and MuFilter
     fScifiDigiHitArray = new TClonesArray("sndScifiHit");


### PR DESCRIPTION
With these changes there will be a trailing dot in the SNDLHCEventHeader branch name, for both MC and data!
I only found, and amended, one instance, inside the 2D ED, where this matters.

Implemented changes fix:
- there isn't a warning/error message when data files and sndsw have different SNDLHCEventHeader class versions
- the SNDLHCEventHeader's UTC timestamp is now being set  for py raw-data conversion too - was missing before
- in the 2dEventDisplay,  all found tracks will be inside OT.Reco_MuonTrack container and accessible outside loopEvent method. Still copying tracks from the tasks' track containers to OT.Reco_MuonTrack.. :/ 