### PR TITLE
First implementation of the newest Layout

### DIFF
--- a/geometry/AdvSND_geom_config.py
+++ b/geometry/AdvSND_geom_config.py
@@ -320,6 +320,7 @@ with ConfigRegistry.register_config("basic") as c:
         c.AdvTarget.nTT = 40
 
         # AdvSND MuFilter structure
+        """
         c.AdvMuFilter = AttrDict(z=0*u.cm)
         c.AdvMuFilter.WallX = 120.0 * u.cm
         c.AdvMuFilter.WallY = 60.0 * u.cm
@@ -328,3 +329,17 @@ with ConfigRegistry.register_config("basic") as c:
         c.AdvMuFilter.PlaneY = c.AdvMuFilter.WallY
         c.AdvMuFilter.PlaneZ = 2 * u.cm
         c.AdvMuFilter.nPlanes = 22
+        """
+
+        #AdvSND MuFilter Layout 2 (SQUARED)
+        c.AdvMuFilter = AttrDict(z=0*u.cm)
+        c.AdvMuFilter.MuonSysPlaneX     = 70.0 * u.cm
+        c.AdvMuFilter.MuonSysPlaneY     = 70.0 * u.cm
+        c.AdvMuFilter.CutOffset         = 5.0 * u.cm
+        c.AdvMuFilter.FeX               = 105.0 * u.cm
+        c.AdvMuFilter.FeY               = c.AdvMuFilter.FeX
+        c.AdvMuFilter.FeZ               = 8.0 * u.cm
+        c.AdvMuFilter.FeGap             = 2.0 * u.cm
+        c.AdvMuFilter.Nplanes           = 22
+        c.AdvMuFilter.CoilX             = c.AdvMuFilter.MuonSysPlaneX
+        c.AdvMuFilter.CoilY             = 2.0 *u.cm 

--- a/python/shipLHC_conf.py
+++ b/python/shipLHC_conf.py
@@ -42,14 +42,14 @@ def configure(run,ship_geo,Gfield=''):
 			parValue = eval('ship_geo.MuFilter.'+parName)
 			MuFilter.SetConfPar("MuFilter/"+parName, parValue)
 		detectorList.append(MuFilter)
-	"""
+	
 	if "Magnet" in ship_geo: #Magnet is only available in advSND geometry files
 		Magnet = ROOT.Magnet("Magnet",ROOT.kTRUE)
 		for parName in ship_geo.Magnet:
 			parValue = eval('ship_geo.Magnet.'+parName)
 			Magnet.SetConfPar("Magnet/"+parName, parValue)
 		detectorList.append(Magnet)
-	
+	"""
 	if "AdvTarget" in ship_geo: #AdvTarget is only available in advSND geometry files
 		AdvTarget = ROOT.AdvTarget("AdvTarget",ROOT.kTRUE)
 		for parName in ship_geo.AdvTarget:

--- a/shipLHC/AdvMuFilter.cxx
+++ b/shipLHC/AdvMuFilter.cxx
@@ -137,7 +137,14 @@ void AdvMuFilter::ConstructGeometry()
 
     InitMedium("polyvinyltoluene");
 	TGeoMedium *Scint = gGeoManager->GetMedium("polyvinyltoluene");
+	
+	InitMedium("CoilCopper");
+	TGeoMedium *Cu = gGeoManager->GetMedium("CoilCopper");
+	
+	InitMedium("Polystyrene");
+    TGeoMedium *Polystyrene = gGeoManager->GetMedium("Polystyrene");
 
+	/*
     Double_t fWallX = conf_floats["AdvMuFilter/WallX"];
     Double_t fWallY = conf_floats["AdvMuFilter/WallY"];
     Double_t fWallZ = conf_floats["AdvMuFilter/WallZ"];
@@ -156,7 +163,7 @@ void AdvMuFilter::ConstructGeometry()
     volMFPlane->SetLineColor(kGray);
     AddSensitiveVolume(volMFPlane);
 
-    //Definition of the target box containing tungsten walls + target trackers (TT) 
+     
     TGeoVolumeAssembly *volAdvMuFilter  = new TGeoVolumeAssembly("volAdvMuFilter");
 
     detector->AddNode(volAdvMuFilter,1,new TGeoTranslation(-2.4244059999999976,0,0));
@@ -176,7 +183,144 @@ void AdvMuFilter::ConstructGeometry()
     }
     LOG(INFO) <<"  MuFilter X: "<< -EmWall0_survey.X()+(fTargetWallX-42.2)/2.<<"  Y: "<< EmWall0_survey.Y()<< "  Z: "<< -TargetDiff+EmWall0_survey.Z()+fWallZ/2.;
 }
+	*/
+	
+	Double_t fMuonSysPlaneX = conf_floats["AdvMuFilter/MuonSysPlaneX"];
+    Double_t fMuonSysPlaneY = conf_floats["AdvMuFilter/MuonSysPlaneY"]; 
+    Double_t fCutOffset     = conf_floats["AdvMuFilter/CutOffset"];  
+    Double_t fFeX           = conf_floats["AdvMuFilter/FeX"];
+    Double_t fFeY           = conf_floats["AdvMuFilter/FeY"];
+    Double_t fFeZ           = conf_floats["AdvMuFilter/FeZ"];  
+    Double_t fFeGap         = conf_floats["AdvMuFilter/FeGap"];  
+    Int_t    fNplanes       = conf_ints["AdvMuFilter/Nplanes"];  
+    Double_t fCoilX         = conf_floats["AdvMuFilter/CoilX"];
+    Double_t fCoilY         = conf_floats["AdvMuFilter/CoilY"];  
+    Double_t fCoilZ         = (fNplanes)*(fFeZ+fFeGap)-fFeGap;
+    Double_t fFeYokeX       = (fFeX-fMuonSysPlaneX)/2.;
+    Double_t fFeYokeY       = (fFeY-fMuonSysPlaneY-fCoilY)/2.;
+    Double_t fFeCutX        = fFeYokeX - fCutOffset;
+    Double_t fFeCutY        = fFeYokeY - fCutOffset;
+    
+    TGeoVolumeAssembly *volAdvMuFilter  = new TGeoVolumeAssembly("volAdvMuFilter");
+    
+    // Moving the detector forward in the Z direction adding:
+    //	-	354.362 which is the last target detector plane midpoint position
+    // 	-	3 is the target detector plane half Z-dimension
+    //	-	1 is the clearance between volAdvTarget and volAdvMuilter
+    
+    Double_t fTargetWallX = 50.; //cm
+    TVector3 EmWall0_survey(5.35+42.2/2.-(fTargetWallX-42.2)/2., 17.2+42.2/2., 288.92+10/2.+100); // cm
 
+    detector->AddNode(volAdvMuFilter,0,new TGeoTranslation(-2.4244059999999976-EmWall0_survey.X(), 38.3, 354.862+3+1+fFeZ/2.-41.895793+1.)); // hardcoded, try to find and elegant solution
+    
+    TGeoBBox *FeWall = new TGeoBBox("FeWall", fFeX/2., fFeY/2., fFeZ/2.);
+    TGeoBBox *MuonSysPlane = new TGeoBBox("MuonSysPlane", fMuonSysPlaneX/2., fMuonSysPlaneY/2., fFeZ/2.+0.001);
+    TGeoBBox *CoilSpace = new TGeoBBox("CoilSpace", fCoilX/2., fCoilY/2.+0.005, fFeZ/2.+0.05);
+    TGeoBBox *Coil = new TGeoBBox("Coil", fCoilX/2., fCoilY/2., fCoilZ/2.);
+    TGeoBBox *MuonSysDet = new TGeoBBox("MuonSysDet", fMuonSysPlaneX/2., fMuonSysPlaneY/2., fFeGap/2.);
+
+    Double_t cutvers[8][2];
+    cutvers[0][0] = 0;
+    cutvers[0][1] = 0;
+    cutvers[1][0] = 0;
+    cutvers[1][1] = -fFeCutY;
+    cutvers[2][0] = 0;
+    cutvers[2][1] = -fFeCutY;
+    cutvers[3][0] = +fFeCutX;
+    cutvers[3][1] = 0;
+
+    cutvers[4][0] = 0;
+    cutvers[4][1] = 0;
+    cutvers[5][0] = 0;
+    cutvers[5][1] = -fFeCutY;
+    cutvers[6][0] = 0;
+    cutvers[6][1] = -fFeCutY;
+    cutvers[7][0] = +fFeCutX;
+    cutvers[7][1] = 0;
+    TGeoArb8 *FeCut = new TGeoArb8("FeCut", fFeZ/2.+0.001, (Double_t *)cutvers);
+
+    TGeoTranslation *CutUpRight = new TGeoTranslation("CutUpRight", -fFeX/2.-0.001, fFeY/2.+0.001, 0);
+    CutUpRight->RegisterYourself();
+    TGeoCombiTrans *CutDownRight = new TGeoCombiTrans( TGeoTranslation(-fFeX/2.-0.001, -fFeY/2.-0.001, 0), TGeoRotation("rot", 0, 0, 90));
+    CutDownRight->SetName("CutDownRight");
+    CutDownRight->RegisterYourself();
+    TGeoCombiTrans *CutDownLeft = new TGeoCombiTrans(TGeoTranslation(+fFeX/2.+0.001, -fFeY/2.-0.001, 0), TGeoRotation("rot1", 0, 0, 180));
+    CutDownLeft->SetName("CutDownLeft");
+    CutDownLeft->RegisterYourself();
+    TGeoCombiTrans *CutUpLeft = new TGeoCombiTrans(TGeoTranslation(+fFeX/2.+0.001, +fFeY/2.+0.001, 0), TGeoRotation("rot2", 0, 0, -90));
+    CutUpLeft->SetName("CutUpLeft");
+    CutUpLeft->RegisterYourself();
+
+
+    TGeoTranslation *CoilUp = new TGeoTranslation("CoilUp", 0, fMuonSysPlaneY/2.+fCoilY/2., 0);
+    TGeoTranslation *CoilDown = new TGeoTranslation("CoilDown", 0, -fMuonSysPlaneY/2.-fCoilY/2., 0);
+    CoilUp->RegisterYourself();
+    CoilDown->RegisterYourself();
+
+    TGeoCompositeShape *MuonSysFe = new TGeoCompositeShape("MuonSysFe", "FeWall-MuonSysPlane-(CoilSpace:CoilUp)-(CoilSpace:CoilDown)-(FeCut:CutUpRight)-(FeCut:CutDownRight)-(FeCut:CutDownLeft)-(FeCut:CutUpLeft)");
+    TGeoVolume *volFeWall = new TGeoVolume("volFeWall", MuonSysFe, Fe);
+    TGeoVolume *volMagFe = new TGeoVolume("volMagFe", MuonSysPlane, Fe);
+    volFeWall->SetLineColor(kGreen-4);
+    volMagFe->SetLineColor(kGreen);
+    
+    //Double_t fField = 1.5; // Tesla
+    //fField = fField/10; // kGauss (complying with GEANT3)
+    Double_t fField = conf_floats["AdvMuFilter/Field"];
+    TGeoUniformMagField *magField = new TGeoUniformMagField(-fField,0, 0);
+    TGeoGlobalMagField::Instance()->SetField(magField);
+    volMagFe->SetField(magField);
+
+    TGeoVolume *volCoil = new TGeoVolume("volCoil", Coil, Cu);
+    volCoil->SetLineColor(kOrange+1);
+
+    TGeoVolume *volMuonSysDet = new TGeoVolume("volMuonSysDet", MuonSysDet, Scint);
+    volMuonSysDet->SetLineColor(kGray-2);
+    AddSensitiveVolume(volMuonSysDet);
+
+    for(int i = 0; i<fNplanes; i++)
+    {
+        volAdvMuFilter->AddNode(volFeWall, i, new TGeoTranslation(0, 0, i*(fFeZ+fFeGap)));
+        volAdvMuFilter->AddNode(volMagFe, i, new TGeoTranslation(0, 0, i*(fFeZ+fFeGap)));
+        if (i == fNplanes-1) continue;
+        volAdvMuFilter->AddNode(volMuonSysDet, i, new TGeoTranslation(0, 0, (fFeZ+fFeGap)/2.+i*(fFeZ+fFeGap)));
+    }
+    volAdvMuFilter->AddNode(volCoil, 0, new TGeoTranslation(0, fMuonSysPlaneY/2.+fCoilY/2., fCoilZ/2.-fFeZ/2.));
+    volAdvMuFilter->AddNode(volCoil, 1, new TGeoTranslation(0, -fMuonSysPlaneY/2.-fCoilY/2., fCoilZ/2.-fFeZ/2.));
+    
+    // Now adding the second part of the spectrometer, TO DO: think about how to implement it in the Magnet.cxx class with all of the shapes.
+    // for now just add a 1000 offset to identify Magnet hits from MuFilter ones
+    Int_t    fDetIDOffset = 1000;
+    Double_t fNplanes2 = 20;
+    Double_t fMagnetsGap = 90+2.5; // cm
+    Double_t FirstMagZ = fNplanes*(fFeZ+fFeGap);
+    Double_t fShortCoilZ = fNplanes2*fFeZ;
+    Double_t fSpacing = 8.75; // cm
+
+    TGeoBBox *ShortCoil = new TGeoBBox("ShortCoil", fCoilX/2., fCoilY/2., fShortCoilZ/2.);
+    TGeoVolume *volShortCoil = new TGeoVolume("volShortCoil", ShortCoil, Cu);
+    volShortCoil->SetLineColor(kOrange+1);
+
+
+    for(int i = 0; i< 20; i++)
+    {
+        volAdvMuFilter->AddNode(volFeWall, i+fNplanes, new TGeoTranslation(0, 0, FirstMagZ+fMagnetsGap+i*fFeZ-fFeGap+fSpacing));
+        volAdvMuFilter->AddNode(volMagFe, i+fNplanes, new TGeoTranslation(0, 0, FirstMagZ+fMagnetsGap+i*fFeZ-fFeGap+fSpacing));
+    }
+    volAdvMuFilter->AddNode(volShortCoil, 0, new TGeoTranslation(0, fMuonSysPlaneY/2.+fCoilY/2., fShortCoilZ/2.-fFeZ/2.+fMagnetsGap+FirstMagZ-fFeGap+fSpacing));
+    volAdvMuFilter->AddNode(volShortCoil, 1, new TGeoTranslation(0, -fMuonSysPlaneY/2.-fCoilY/2., fShortCoilZ/2.-fFeZ/2.+fMagnetsGap+FirstMagZ-fFeGap+fSpacing));
+
+
+    // Trackers part
+    Double_t fMagTrackerZ = 2.5; // cm Alu tubes diameter
+    TGeoBBox *MagTracker = new TGeoBBox("MagTracker", fMuonSysPlaneX/2., fMuonSysPlaneY/2., fMagTrackerZ/2.);
+    TGeoVolume *volMagTracker = new TGeoVolume("volMagTracker", MagTracker, Polystyrene);
+    volMagTracker->SetLineColor(kGray);
+	AddSensitiveVolume(volMagTracker);
+	
+    volAdvMuFilter->AddNode(volMagTracker, 0+fDetIDOffset, new TGeoTranslation(0, 0, FirstMagZ-fFeZ/2.-fFeGap+fMagTrackerZ/2.));
+    volAdvMuFilter->AddNode(volMagTracker, 1+fDetIDOffset, new TGeoTranslation(0, 0, FirstMagZ-fFeZ/2.-fFeGap+fMagnetsGap-fMagTrackerZ/2.));
+    volAdvMuFilter->AddNode(volMagTracker, 2+fDetIDOffset, new TGeoTranslation(0, 0, FirstMagZ-fFeZ/2.-fFeGap+fMagnetsGap+fShortCoilZ+fMagTrackerZ/2.+2*fSpacing));
+}
 Bool_t  AdvMuFilter::ProcessHits(FairVolume* vol)
 {
   /** This method is called from the MC stepping */


### PR DESCRIPTION
As the title says, this adds the newest layout from W.S. Parzefall's slides of the previous SND@LHC Collaboration Meeting. Moreover, accounting also for the squared transverse area of the newest target, the dimensions of the sensitive planes of the detector are set to 70x70 cm^2.
HL-LHC muon background simulations have been launched taking into account such a new geometry.