### PR TITLE
Adding options to activate emulsions and change number in brick

### DIFF
--- a/geometry/sndLHC_geom_config.py
+++ b/geometry/sndLHC_geom_config.py
@@ -2,6 +2,10 @@ import ROOT as r
 import shipunit as u
 from ShipGeoConfig import AttrDict, ConfigRegistry
 
+if "nuTargetPassive" not in globals():
+    nuTargetPassive = 1
+if "useNagoyaEmulsions" not in globals():
+    useNagoyaEmulsions=False
 
 with ConfigRegistry.register_config("basic") as c:
 # cave parameters
@@ -10,7 +14,7 @@ with ConfigRegistry.register_config("basic") as c:
         # Antonia, 482000mm (FASER+2, P3) + 1017mm (DZ) + 245mm (centre emulsion),z=483262./10.*u.cm
         # centre emulsion now 326.2cm downstream from origin.
         c.EmulsionDet = AttrDict(z=326.2*u.cm)
-        c.EmulsionDet.PassiveOption = 1 #0 makes emulsion volumes active, 1 makes all emulsion volumes passive
+        c.EmulsionDet.PassiveOption = nuTargetPassive #0 makes emulsion volumes active, 1 makes all emulsion volumes passive
         c.EmulsionDet.row = 2
         c.EmulsionDet.col = 2
         c.EmulsionDet.wall= 5
@@ -19,7 +23,11 @@ with ConfigRegistry.register_config("basic") as c:
         c.EmulsionDet.EmTh = 0.0070 * u.cm
         c.EmulsionDet.EmX = 19.2 * u.cm
         c.EmulsionDet.EmY = 19.2 * u.cm
-        c.EmulsionDet.PBTh = 0.0175 * u.cm
+        c.EmulsionDet.PBTh = 0.0175 * u.cm        
+        if (useNagoyaEmulsions):
+                c.EmulsionDet.n_plates = 56
+                c.EmulsionDet.PBTh = 0.0195 * u.cm
+
         c.EmulsionDet.PassiveTh = 0.1 * u.cm
         c.EmulsionDet.EPlW = 2* c.EmulsionDet.EmTh + c.EmulsionDet.PBTh
         c.EmulsionDet.AllPW = c.EmulsionDet.PassiveTh + c.EmulsionDet.EPlW

--- a/geometry/sndLHC_geom_config.py
+++ b/geometry/sndLHC_geom_config.py
@@ -3,7 +3,7 @@ import shipunit as u
 from ShipGeoConfig import AttrDict, ConfigRegistry
 
 if "nuTargetPassive" not in globals():
-    nuTargetPassive = 1
+    nuTargetPassive = True
 if "useNagoyaEmulsions" not in globals():
     useNagoyaEmulsions=False
 

--- a/shipLHC/run_simSND.py
+++ b/shipLHC/run_simSND.py
@@ -48,7 +48,7 @@ parser.add_argument("--boostFactor", dest="boostFactor",  help="boost mu brems",
 parser.add_argument("--enhancePiKaDecay", dest="enhancePiKaDecay",  help="decrease charged pion and kaon lifetime", required=False, type=float,default=0.)
 parser.add_argument("--debug",   dest="debug",   help="debugging mode, check for overlaps", required=False, action="store_true")
 parser.add_argument("-D", "--display", dest="eventDisplay", help="store trajectories", required=False, action="store_true")
-parser.add_argument("--EmuDet","--nuTargetActive",dest="nuTargetActive",help="activate emulsiondetector", required=False,action="store_true")
+parser.add_argument("--EmuDet","--nuTargetActive",dest="nuTargetPassive",help="activate emulsiondetector", required=False,action="store_false")
 parser.add_argument("--NagoyaEmu","--useNagoyaEmulsions",dest="useNagoyaEmulsions",help="use bricks of 57 Nagoya emulsion films instead of 60 Slavich", required=False,action="store_true")
 
 options = parser.parse_args()
@@ -107,7 +107,7 @@ shipRoot_conf.configure(0)     # load basic libraries, prepare atexit for python
 
 if options.testbeam:  snd_geo = ConfigRegistry.loadpy("$SNDSW_ROOT/geometry/sndLHC_H6geom_config.py")
 else:                         snd_geo = ConfigRegistry.loadpy("$SNDSW_ROOT/geometry/sndLHC_geom_config.py",
-                                                                  nuTargetPassive = not options.nuTargetActive, useNagoyaEmulsions = options.useNagoyaEmulsions)
+                                                                  nuTargetPassive = options.nuTargetPassive, useNagoyaEmulsions = options.useNagoyaEmulsions)
 
 if simEngine == "PG": tag = simEngine + "_"+str(options.pID)+"-"+mcEngine
 else: tag = simEngine+"-"+mcEngine

--- a/shipLHC/run_simSND.py
+++ b/shipLHC/run_simSND.py
@@ -48,6 +48,8 @@ parser.add_argument("--boostFactor", dest="boostFactor",  help="boost mu brems",
 parser.add_argument("--enhancePiKaDecay", dest="enhancePiKaDecay",  help="decrease charged pion and kaon lifetime", required=False, type=float,default=0.)
 parser.add_argument("--debug",   dest="debug",   help="debugging mode, check for overlaps", required=False, action="store_true")
 parser.add_argument("-D", "--display", dest="eventDisplay", help="store trajectories", required=False, action="store_true")
+parser.add_argument("--EmuDet","--nuTargetActive",dest="nuTargetActive",help="activate emulsiondetector", required=False,action="store_true")
+parser.add_argument("--NagoyaEmu","--useNagoyaEmulsions",dest="useNagoyaEmulsions",help="use bricks of 57 Nagoya emulsion films instead of 60 Slavich", required=False,action="store_true")
 
 options = parser.parse_args()
 
@@ -104,7 +106,8 @@ ROOT.gRandom.SetSeed(options.theSeed)  # this should be propagated via ROOT to P
 shipRoot_conf.configure(0)     # load basic libraries, prepare atexit for python
 
 if options.testbeam:  snd_geo = ConfigRegistry.loadpy("$SNDSW_ROOT/geometry/sndLHC_H6geom_config.py")
-else:                         snd_geo = ConfigRegistry.loadpy("$SNDSW_ROOT/geometry/sndLHC_geom_config.py")
+else:                         snd_geo = ConfigRegistry.loadpy("$SNDSW_ROOT/geometry/sndLHC_geom_config.py",
+                                                                  nuTargetPassive = not options.nuTargetActive, useNagoyaEmulsions = options.useNagoyaEmulsions)
 
 if simEngine == "PG": tag = simEngine + "_"+str(options.pID)+"-"+mcEngine
 else: tag = simEngine+"-"+mcEngine


### PR DESCRIPTION
Dear all SNDSW users,

This  small pull request add two options to run_simSND.py, with the aim of helping in performing simulations with emulsions active, without having to build sndsw each time by changing the PassiveOption parameter in sndLHC_geom_config.py

This way, simply adding --EmuDet to run_simSND.py makes the detector active.

Moreover, --NagoyaEmu replaces the default bricks with 60 Slavich emulsion films with 57 Nagoya emulsion films (only differences implemented are number and thickness, 195 micron instead of 175 micron). Actual material composition is not changed. Currently, due to the replica implementation, all bricks have to be changed. 

Naturally, without using these options the configuration is the same as before.
Unfortunately, I have not yet found an efficient way to have part of the target with Nagoya and part with Slavich films, as in the real target. Moreover, the possibility of activating only one brick is under discussion  after it was mentioned in the last Collaboration Meeting.

Best Regards,
Antonio Iuliano

