### PR TITLE
Fix README to allow copying of commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ On `lxplus` or any CC7/CC8 machine with access to CVMFS, you can do the followin
     ```
 2. Source the `setUp.sh` script
     ```bash
-    source /cvmfs/sndlhc.cern.ch/SNDLHC-2023/Aug30/setUp.sh (recommended latest version)
+    source /cvmfs/sndlhc.cern.ch/SNDLHC-2023/Aug30/setUp.sh  # recommended latest version
     ```
 3. If you don't want to modify the sndsw package, skip step 3:
     ```bash


### PR DESCRIPTION
Since the comment is in parentheses instead of commented, if the command is copied it will cause an error.