### PR TITLE
ShipCave.cxx: Don't include unneeded (or nonexistent!) headers

### DIFF
--- a/passive/ShipCave.cxx
+++ b/passive/ShipCave.cxx
@@ -2,21 +2,6 @@
 #include "ShipCave.h"
 
 #include "ShipGeoCave.h"                // for ShipGeoCave
-#include "FairGeoInterface.h"           // for FairGeoInterface
-#include "FairGeoLoader.h"              // for FairGeoLoader
-#include "FairGeoNode.h"                // for FairGeoNode
-#include "FairGeoPassivePar.h"          // for FairGeoPassivePar
-#include "FairGeoVolume.h"              // for FairGeoVolume
-#include "FairRun.h"                    // for FairRun
-#include "FairRuntimeDb.h"              // for FairRuntimeDb
-
-#include "TList.h"                      // for TListIter, TList (ptr only)
-#include "TObjArray.h"                  // for TObjArray
-#include "TString.h"                    // for TString
-
-#include <stddef.h>                     // for NULL
-
-ClassImp(ShipCave)
 
 void ShipCave::ConstructGeometry()
 {


### PR DESCRIPTION
It seems like the `FairGeoPassivePar.h` header only exists in FairRoot examples, resulting in a build issue.

On further investigation, I noticed that none of the headers besides `ShipCave.h` and `ShipGeoCave.h` here are needed (most are already transitively included). I also remove the `ClassImp` while I'm touching the file (see https://github.com/ShipSoft/FairShip/pull/404).

Builds fine on my machine and can run simulations (i.e. construct the geometry) fine.