### PR TITLE
Fix: Use SetSink instead of deprecated SetOutputFile

### DIFF
--- a/macro/eventDisplay_shipLHC.py
+++ b/macro/eventDisplay_shipLHC.py
@@ -850,7 +850,7 @@ else:
  fRun.SetInputFile(options.InputFile)
 if options.OutputFile == None:
   options.OutputFile = ROOT.TMemFile('event_display_output', 'recreate')
-fRun.SetOutputFile(options.OutputFile)
+fRun.SetSink(ROOT.FairRootFileSink(options.OutputFile))
 
 if options.ParFile:
  rtdb      = fRun.GetRuntimeDb()

--- a/macro/inspectGeant4Geo.py
+++ b/macro/inspectGeant4Geo.py
@@ -17,7 +17,7 @@ ShipGeo = upkl.load('ShipGeo')
 modules = shipDet_conf.configure(run, ShipGeo)
 run.SetUserConfig('g4Config.C')
 run.SetName('TGeant4')
-run.SetOutputFile(ROOT.TMemFile('output', 'recreate'))
+run.SetSink(ROOT.FairRootFileSink(ROOT.TMemFile('output', 'recreate')))
 run.Init()
 run.Run(0)
 import geomGeant4

--- a/python/SciFiMapping.py
+++ b/python/SciFiMapping.py
@@ -18,7 +18,7 @@ if __name__ == "__main__":
 
 	run = ROOT.FairRunSim()
 	run.SetName("TGeant4")  # Transport engine
-	run.SetOutputFile(ROOT.TMemFile('output', 'recreate'))  # Output file
+	run.SetSink(ROOT.FairRootFileSink(ROOT.TMemFile('output', 'recreate')))  # Output file
 	run.SetUserConfig("g4Config_basic.C") # geant4 transport not used
 	rtdb = run.GetRuntimeDb()
 	modules = sndDet_conf.configure(run,snd_geo)

--- a/shipLHC/makeGeoFile.py
+++ b/shipLHC/makeGeoFile.py
@@ -20,7 +20,7 @@ snd_geo = ConfigRegistry.loadpy(options.config)
 # -----Create simulation run----------------------------------------
 run = ROOT.FairRunSim()
 run.SetName(mcEngine)  # Transport engine
-run.SetOutputFile("dummy.root")  # Output file
+run.SetSink(ROOT.FairRootFileSink(ROOT.TMemFile('output', 'recreate')))  # output file
 run.SetUserConfig("g4Config.C") # user configuration file default g4Config.C 
 rtdb = run.GetRuntimeDb() 
 
@@ -46,4 +46,3 @@ run.CreateGeometryFile(options.geofile)
 # save detector parameters dictionary in geofile
 import saveBasicParameters
 saveBasicParameters.execute(options.geofile,snd_geo)
-

--- a/shipLHC/run_simSND.py
+++ b/shipLHC/run_simSND.py
@@ -133,7 +133,7 @@ timer.Start()
 # -----Create simulation run----------------------------------------
 run = ROOT.FairRunSim()
 run.SetName(mcEngine)  # Transport engine
-run.SetOutputFile(outFile)  # Output file
+run.SetSink(ROOT.FairRootFileSink(outFile))  # Output file
 run.SetUserConfig("g4Config.C") # user configuration file default g4Config.C 
 rtdb = run.GetRuntimeDb() 
 # add user task

--- a/shipLHC/scripts/scifiSimAna.py
+++ b/shipLHC/scripts/scifiSimAna.py
@@ -28,7 +28,7 @@ import shipLHC_conf as sndDet_conf
 
 run = ROOT.FairRunSim()
 run.SetName("TGeant4")  # Transport engine
-run.SetOutputFile(ROOT.TMemFile('output', 'recreate'))  # Output file
+run.SetSink(ROOT.FairRootFileSink(ROOT.TMemFile('output', 'recreate')))  # Output file
 run.SetUserConfig("g4Config_basic.C") # geant4 transport not used
 rtdb = run.GetRuntimeDb()
 modules = sndDet_conf.configure(run,snd_geo)

--- a/shipLHC/thermalNeutrons.py
+++ b/shipLHC/thermalNeutrons.py
@@ -49,7 +49,7 @@ timer.Start()
 # -----Create simulation run----------------------------------------
 run = ROOT.FairRunSim()
 run.SetName('TGeant4')  # Transport engine
-run.SetOutputFile(outFile)  # Output file
+run.SetSink(ROOT.FairRootFileSink(outFile))  # Output file
 run.SetUserConfig("g4ConfigNeutron.C") # user configuration file default g4Config.C
 
 # -----Create PrimaryGenerator--------------------------------------


### PR DESCRIPTION
Fixes #165 

I also change the output file to a memory file in `shipLHC/makeGeoFile.py` instead of creating an empty dummy file.