### PR TITLE
eventDisplay: Remove workaround for old ROOT versions

### DIFF
--- a/macro/eventDisplay_shipLHC.py
+++ b/macro/eventDisplay_shipLHC.py
@@ -13,13 +13,6 @@ from decorators import *
 import shipRoot_conf,shipLHC_conf
 shipRoot_conf.configure()
 
-def evExit():
- if ROOT.gROOT.FindObject('Root Canvas EnergyLoss'):
-  print("make suicide before framework makes seg fault") 
-  os.kill(os.getpid(),9)
-# apperantly problem disappeared in more recent root versions
-if float(ROOT.gROOT.GetVersion().split('/')[0])>6.07: atexit.register(evExit)
-
 fMan = None
 fRun = None
 pdg  = ROOT.TDatabasePDG.Instance()


### PR DESCRIPTION
As sndsw was never used with a ROOT version older than the one mentioned, it should be safe to remove this.

Note: it seems like this version check might be the wrong way round, it's true for versions larger than 6.07. Not sure whether this was intended.

I'm also confused, as I get a segmentation fault with and without this code when closing the Eve window manually and then exiting the python prompt.