### PR TITLE
makeGeoFile: No argument group needed (or used)

### DIFF
--- a/shipLHC/makeGeoFile.py
+++ b/shipLHC/makeGeoFile.py
@@ -7,7 +7,6 @@ from argparse import ArgumentParser
 mcEngine     = "TGeant4"
 
 parser = ArgumentParser()
-group = parser.add_mutually_exclusive_group()
 
 parser.add_argument("-c",   dest="config",   help="configuration file", required=True)
 parser.add_argument("-g",   dest="geofile",   help="geo file output name", required=True)


### PR DESCRIPTION
Probably because of copy/pasting from `run_simSND`, where it was removed in #156 