### PR TITLE
eventDisplay: No need to commit suicide if you can disown

### DIFF
--- a/macro/eventDisplay_shipLHC.py
+++ b/macro/eventDisplay_shipLHC.py
@@ -13,12 +13,15 @@ from decorators import *
 import shipRoot_conf,shipLHC_conf
 shipRoot_conf.configure()
 
+
 def evExit():
- if ROOT.gROOT.FindObject('Root Canvas EnergyLoss'):
-  print("make suicide before framework makes seg fault") 
-  os.kill(os.getpid(),9)
-# apperantly problem disappeared in more recent root versions
-if float(ROOT.gROOT.GetVersion().split('/')[0])>6.07: atexit.register(evExit)
+    """Prevent double delete due to a FairRoot bug."""
+    # Check whether the Eve window was closed/destructed
+    if ROOT.addressof(ROOT.gEve) == 0:
+        # Prevent the FairEventManager destructor from being called
+        ROOT.SetOwnership(fMan, False)
+
+atexit.register(evExit)
 
 fMan = None
 fRun = None


### PR DESCRIPTION
Supersedes #174.

I think this is a bug in FairEventManager, whose destructor causes a segmentation violation if the Eve window is closed.

By checking whether the Eve window has been destructed (it will be a NULL pointer), we can disown to prevent FairEventManager from being destroyed. Maybe some of the class members are safe to destroy, but at least one of them is already deleted.

PS: As this is a bug in FairRoot, there is no need to check for the ROOT version.