### PR TITLE
Fix memory leak in muon reconstruction

### DIFF
--- a/python/SndlhcMuonReco.py
+++ b/python/SndlhcMuonReco.py
@@ -959,6 +959,8 @@ class MuonReco(ROOT.FairTask) :
                   this_track.setTrackType(self.track_type)
                   # Save the track in sndRecoTrack format
                   self.kalman_tracks[i_muon] = this_track
+                  # Delete the Kalman track object
+                  theTrack.Delete()
 
             # Remove track hits and try to find an additional track
             # Find array index to be removed


### PR DESCRIPTION
When saving the muon tracks in the sndRecoTrack format, the genfit Kalman track object is not being deleted at the end of the fit, resulting in a memory leak.