### PR TITLE
README: update HTCondor instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ To load the `sndsw` environment, after you build the software, you can simply us
 However, this won't work if you are using HTCondor. In such case you can do:
 
 ```bash
-eval alienv load sndsw/latest
+eval $(alienv load sndsw/latest --no-refresh)
 ```
 
 If you modify `sndsw`, simply repeat step 4 from `sndsw`'s parent directory.


### PR DESCRIPTION
* the `alienv` command should be surrounded by backticks, or better `$()` to ensure that the output of `alienv` is evaluated, and not just the `alienv command` (see #183)
* add `--no-refresh option`, which seems to fixes a race condition where multiple jobs try to refresh the module files at the same time.