### PR TITLE
2d ed fix and update

### DIFF
--- a/shipLHC/scripts/2dEventDisplay.py
+++ b/shipLHC/scripts/2dEventDisplay.py
@@ -1,9 +1,9 @@
 import ROOT
 import os,sys,subprocess,atexit
-import rootUtils as ut
 from array import array
 import shipunit as u
 import SndlhcMuonReco
+import rootUtils as ut
 import json
 from decorators import *
 from rootpyPickler import Unpickler


### PR DESCRIPTION

- fix canvas drawing in the 2dED
- read event info straight from the event header and not the run_timestamps.json stored with the raw data. This is especially important in the prospect of deleting the archived /raw_data from EOS to free up space.