### PR TITLE
Speed up GetCorrectedTime and GetSiPMPosition methods by reading the covered runs only once.

### DIFF
--- a/shipLHC/MuFilter.h
+++ b/shipLHC/MuFilter.h
@@ -39,8 +39,7 @@ class MuFilter : public FairDetector
                  Int_t GetnSiPMs(Int_t detID);
                  Int_t GetnSides(Int_t detID);
 
-		void InitEvent(SNDLHCEventHeader *e){    eventHeader = e;// get mapping to eventHeader
-		}	
+                void InitEvent(SNDLHCEventHeader *e);
 		void SetConfPar(TString name, Float_t value){conf_floats[name]=value;}
 		void SetConfPar(TString name, Int_t value){conf_ints[name]=value;}
 		void SetConfPar(TString name, TString value){conf_strings[name]=value;}
@@ -104,6 +103,11 @@ class MuFilter : public FairDetector
 		std::map<TString,TString> conf_strings;
 		SNDLHCEventHeader *eventHeader;
 
+                // Vector to store runs covered in the geometry file.
+                std::vector<int> covered_runs_time_alignment;
+                TString last_time_alignment_tag;
+                int last_run;
+                bool alignment_init;
 	protected:
 
 			Int_t InitMedium(const char* name);

--- a/shipLHC/Scifi.h
+++ b/shipLHC/Scifi.h
@@ -49,8 +49,7 @@ public:
     Float_t  GetConfParF(TString name){return conf_floats[name];} 
     Int_t       GetConfParI(TString name){return conf_ints[name];}
     TString  GetConfParS(TString name){return conf_strings[name];}
-    void InitEvent(SNDLHCEventHeader *e){    eventHeader = e;// get mapping to eventHeader
-    }
+    void InitEvent(SNDLHCEventHeader *e);
 
     /**      Initialization of the detector is done here    */
     virtual void Initialize();
@@ -120,6 +119,14 @@ private:
     std::map<TString,Int_t> conf_ints;
     std::map<TString,TString> conf_strings;
     SNDLHCEventHeader *eventHeader;
+
+    // Vector to store runs covered in the geometry file.
+    std::vector<int> covered_runs_time_alignment;
+    std::vector<int> covered_runs_position_alignment;
+    int last_run;
+    TString last_time_alignment_tag;
+    TString last_position_alignment_tag;
+    bool alignment_init;
 protected:
     
     Int_t InitMedium(const char* name);


### PR DESCRIPTION
Speeds up the GetCorrectedTime by about a factor of 6.