### PR TITLE
Define last_run parameters per time and position detector functions

### DIFF
--- a/shipLHC/MuFilter.cxx
+++ b/shipLHC/MuFilter.cxx
@@ -61,7 +61,8 @@ fTime(-1.),
 fLength(-1.),
 fELoss(-1),
 eventHeader(0),
-last_run(-1),
+last_run_time(-1),
+last_run_pos(-1),
 last_time_alignment_tag(""),
 alignment_init(false),
 fMuFilterPointCollection(new TClonesArray("MuFilterPoint"))
@@ -78,7 +79,8 @@ fTime(-1.),
 fLength(-1.),
 fELoss(-1),
 eventHeader(0),
-last_run(-1),
+last_run_time(-1),
+last_run_pos(-1),
 last_time_alignment_tag(""),
 alignment_init(false),
 fMuFilterPointCollection(new TClonesArray("MuFilterPoint"))
@@ -548,8 +550,8 @@ Float_t MuFilter::GetCorrectedTime(Int_t fDetectorID, Int_t channel, Double_t ra
 	TString tag = "";
 	if (eventHeader){
 		Int_t fRunNumber = eventHeader->GetRunId();
-		if (fRunNumber != last_run){
-		  last_run = fRunNumber;
+		if (fRunNumber != last_run_time){
+		  last_run_time = fRunNumber;
 
 		  if (fRunNumber<1){
 		  	LOG(ERROR) << "MuFilter::GetCorrectedTime: non valid run number "<<fRunNumber;

--- a/shipLHC/MuFilter.h
+++ b/shipLHC/MuFilter.h
@@ -106,7 +106,7 @@ class MuFilter : public FairDetector
                 // Vector to store runs covered in the geometry file.
                 std::vector<int> covered_runs_time_alignment;
                 TString last_time_alignment_tag;
-                int last_run;
+                int last_run_time, last_run_pos;
                 bool alignment_init;
 	protected:
 

--- a/shipLHC/Scifi.cxx
+++ b/shipLHC/Scifi.cxx
@@ -53,7 +53,8 @@ fTime(-1.),
 fLength(-1.),
 fELoss(-1),
 eventHeader(0),
-last_run(-1),
+last_run_time(-1),
+last_run_pos(-1),
 last_time_alignment_tag(""),
 last_position_alignment_tag(""),
 alignment_init(false),
@@ -71,7 +72,8 @@ fTime(-1.),
 fLength(-1.),
 fELoss(-1),
 eventHeader(0),
-last_run(-1),
+last_run_time(-1),
+last_run_pos(-1),
 last_time_alignment_tag(""),
 last_position_alignment_tag(""),
 alignment_init(false),
@@ -517,8 +519,8 @@ Double_t Scifi::GetCorrectedTime(Int_t fDetectorID, Double_t rawTime, Double_t L
 
 	if (eventHeader){
 		Int_t fRunNumber = eventHeader->GetRunId();
-		if (fRunNumber != last_run){
-		  last_run = fRunNumber;
+		if (fRunNumber != last_run_time){
+		  last_run_time = fRunNumber;
 		  if (fRunNumber<1) {
 		  	LOG(ERROR) << "Scifi::GetCorrectedTime: non valid run number "<<fRunNumber;
 		  	return rawTime;
@@ -638,8 +640,8 @@ void Scifi::GetSiPMPosition(Int_t SiPMChan, TVector3& A, TVector3& B)
 	// in case of old data with FairEventHeader, user will be responsible to use the correct geofile.
 	if (eventHeader){
 		Int_t fRunNumber = eventHeader->GetRunId();
-		if (fRunNumber != last_run){
-		  last_run = fRunNumber;
+		if (fRunNumber != last_run_pos){
+		  last_run_pos = fRunNumber;
 
 		  if (fRunNumber<1) {
 		  LOG(ERROR) << "Scifi::GetSiPMPosition: non valid run number "<<fRunNumber;

--- a/shipLHC/Scifi.h
+++ b/shipLHC/Scifi.h
@@ -123,7 +123,7 @@ private:
     // Vector to store runs covered in the geometry file.
     std::vector<int> covered_runs_time_alignment;
     std::vector<int> covered_runs_position_alignment;
-    int last_run;
+    int last_run_time, last_run_pos;
     TString last_time_alignment_tag;
     TString last_position_alignment_tag;
     bool alignment_init;


### PR DESCRIPTION
One needs two sets of last_run detector parameters to keep track of position and time related alignment tags.