### PR TITLE
Veto3

### DIFF
--- a/geometry/sndLHC_TI18geom_config.py
+++ b/geometry/sndLHC_TI18geom_config.py
@@ -1,12 +1,13 @@
 import ROOT as r
 import shipunit as u
 from ShipGeoConfig import AttrDict, ConfigRegistry
-
+if "year" in globals():
+    year = int(globals()["year"])
 
 with ConfigRegistry.register_config("basic") as c:
 # cave parameters
         c.cave = AttrDict(z=0*u.cm)
-
+        
         # Antonia, 482000mm (FASER+2, P3) + 1017mm (DZ) + 245mm (centre emulsion),z=483262./10.*u.cm
         # centre emulsion now 326.2cm downstream from origin.
         c.EmulsionDet = AttrDict(z=326.2*u.cm)
@@ -157,10 +158,16 @@ with ConfigRegistry.register_config("basic") as c:
         c.Scifi.station5t,c.Scifi.station5H0t,c.Scifi.station5H1t,c.Scifi.station5H2t,c.Scifi.station5V0t,c.Scifi.station5V1t,c.Scifi.station5V2t  =   0.337*u.ns,  0.000*u.ns,  -1.157*u.ns,  -1.060*u.ns,   -0.627*u.ns,  -2.405*u.ns,  0.071*u.ns
 
         c.MuFilter = AttrDict(z=0*u.cm)
+        
         #coordinates in local gravity based system
-        c.MuFilter.Veto1Dx,c.MuFilter.Veto1Dy,c.MuFilter.Veto1Dz = 40.8*u.mm, 2798.3*u.mm, 192.1*u.mm
-        c.MuFilter.Veto2Dx,c.MuFilter.Veto2Dy,c.MuFilter.Veto2Dz = 40.6*u.mm, 2839.3*u.mm, 172.1*u.mm       
-        c.MuFilter.Veto3Dx,c.MuFilter.Veto3Dy,c.MuFilter.Veto3Dz = 40.6*u.mm, 2879.3*u.mm, 152.1*u.mm
+        if year == 2024:
+          c.MuFilter.Veto1Dx,c.MuFilter.Veto1Dy,c.MuFilter.Veto1Dz = 40.8*u.mm, 2761.2*u.mm, 164.3*u.mm
+          c.MuFilter.Veto2Dx,c.MuFilter.Veto2Dy,c.MuFilter.Veto2Dz = 40.6*u.mm, 2802.2*u.mm, 144.3*u.mm
+          c.MuFilter.Veto3Dx,c.MuFilter.Veto3Dy,c.MuFilter.Veto3Dz = 40.4*u.mm, 2843.3*u.mm, 125.8*u.mm
+        else:
+          c.MuFilter.Veto1Dx,c.MuFilter.Veto1Dy,c.MuFilter.Veto1Dz = 40.8*u.mm, 2798.3*u.mm, 192.1*u.mm
+          c.MuFilter.Veto2Dx,c.MuFilter.Veto2Dy,c.MuFilter.Veto2Dz = 40.6*u.mm, 2839.3*u.mm, 172.1*u.mm
+
         c.MuFilter.Iron1Dx, c.MuFilter.Iron1Dy, c.MuFilter.Iron1Dz = -22.1*u.mm, 3579.6*u.mm, 146.6*u.mm   
         # US1
         c.MuFilter.Muon1Dx,c.MuFilter.Muon1Dy,c.MuFilter.Muon1Dz = -46.6*u.mm, 3760.2*u.mm, 128.6 *u.mm  
@@ -210,7 +217,8 @@ with ConfigRegistry.register_config("basic") as c:
         #Veto station parameters
         c.MuFilter.VetonSiPMs = 8
         c.MuFilter.VetonSides  = 2
-        c.MuFilter.NVetoPlanes = 3
+        if year == 2024: c.MuFilter.NVetoPlanes = 3
+        else: c.MuFilter.NVetoPlanes = 2
         c.MuFilter.NVetoBars    = 7
 
         c.MuFilter.VetoBarX,c.MuFilter.VetoBarY,c.MuFilter.VetoBarZ = 42 *u.cm, 6 * u.cm, 1 * u.cm
@@ -253,8 +261,10 @@ with ConfigRegistry.register_config("basic") as c:
         c.MuFilter.USBoxY1        = c.MuFilter.DSHLocY - c.MuFilter.DownstreamBarZ/2 - c.MuFilter.SupportBoxD
         c.MuFilter.USBoxY2        = c.MuFilter.DSHLocY + c.MuFilter.DownstreamBarZ/2 + c.MuFilter.SupportBoxD
 
-       # VETO support box
+       # VETO support box 
         c.MuFilter.SupportBoxVW = 4*u.mm
+        if year == 2024:
+          c.MuFilter.SupportBoxVW = 6*u.mm # FIXME
         c.MuFilter.VETOBoxX1        = c.MuFilter.VETOLocX - c.MuFilter.SupportBoxD
         c.MuFilter.VETOBoxX2        = c.MuFilter.VETOLocX + c.MuFilter.VetoBarX + c.MuFilter.SupportBoxD
         
@@ -266,10 +276,8 @@ with ConfigRegistry.register_config("basic") as c:
         
         c.MuFilter.VETOBoxZ3        = c.MuFilter.VETOLocZ - c.MuFilter.SupportBoxD
         c.MuFilter.VETOBoxZ4        = c.MuFilter.VETOLocZ + c.MuFilter.Veto3BarY + c.MuFilter.SupportBoxD
-
         c.MuFilter.VETOBoxY1        = c.MuFilter.VETOLocY - c.MuFilter.VetoBarZ/2 - c.MuFilter.SupportBoxD
         c.MuFilter.VETOBoxY2        = c.MuFilter.VETOLocY + c.MuFilter.VetoBarZ/2 + c.MuFilter.SupportBoxD
-
         c.MuFilter.VETOBoxY3        = c.MuFilter.VETOLocY - c.MuFilter.Veto3BarZ/2 - c.MuFilter.SupportBoxD
         c.MuFilter.VETOBoxY4        = c.MuFilter.VETOLocY + c.MuFilter.Veto3BarZ/2 + c.MuFilter.SupportBoxD
 
@@ -305,14 +313,16 @@ with ConfigRegistry.register_config("basic") as c:
         c.Floor.DX = 1.0*u.cm 
         c.Floor.DY = -4.5*u.cm #  subtract 4.5cm to avoid overlaps 
         c.Floor.DZ = 0.
+
         
-        # Pit on the tunnel floor hosting Veto - using survey coord. system
-        # Dimensions
-        c.Floor.VetoPitXdim, c.Floor.VetoPitYdim, c.Floor.VetoPitZdim = 500*u.mm, 200*u.mm, 86*u.mm
-        # Position == Emuslion wall 1 + a correction in Z
-        c.Floor.VetoPitX =  c.EmulsionDet.Xpos0
-        c.Floor.VetoPitY =  c.EmulsionDet.Ypos0
-        c.Floor.VetoPitZ =  c.EmulsionDet.Zpos0 + c.EmulsionDet.WallZBorder_offset
+        if year == 2024:
+          # Pit on the tunnel floor hosting Veto - using survey coord. system
+          # Dimensions
+          c.Floor.VetoPitXdim, c.Floor.VetoPitYdim, c.Floor.VetoPitZdim = 500*u.mm, 200*u.mm, 86*u.mm
+          # Position == Emuslion wall 1 + a correction in Z
+          c.Floor.VetoPitX =  c.EmulsionDet.Xpos0
+          c.Floor.VetoPitY =  c.EmulsionDet.Ypos0
+          c.Floor.VetoPitZ =  c.EmulsionDet.Zpos0 + c.EmulsionDet.WallZBorder_offset
 
         #COLDBOX configuration
         c.Floor.Acrylic_width = 5.0*u.cm

--- a/geometry/sndLHC_TI18geom_config.py
+++ b/geometry/sndLHC_TI18geom_config.py
@@ -161,9 +161,9 @@ with ConfigRegistry.register_config("basic") as c:
         
         #coordinates in local gravity based system
         if year == 2024:
-          c.MuFilter.Veto1Dx,c.MuFilter.Veto1Dy,c.MuFilter.Veto1Dz = 40.8*u.mm, 2761.2*u.mm, 164.3*u.mm
-          c.MuFilter.Veto2Dx,c.MuFilter.Veto2Dy,c.MuFilter.Veto2Dz = 40.6*u.mm, 2802.2*u.mm, 144.3*u.mm
-          c.MuFilter.Veto3Dx,c.MuFilter.Veto3Dy,c.MuFilter.Veto3Dz = 40.4*u.mm, 2843.3*u.mm, 125.8*u.mm
+          c.MuFilter.Veto1Dx,c.MuFilter.Veto1Dy,c.MuFilter.Veto1Dz = 49.3*u.mm, 2761.1*u.mm, 168.1*u.mm
+          c.MuFilter.Veto2Dx,c.MuFilter.Veto2Dy,c.MuFilter.Veto2Dz = 49.3*u.mm, 2802.1*u.mm, 148.1*u.mm
+          c.MuFilter.Veto3Dx,c.MuFilter.Veto3Dy,c.MuFilter.Veto3Dz = 61.8*u.mm, 2863.1*u.mm, 146.6*u.mm
         else:
           c.MuFilter.Veto1Dx,c.MuFilter.Veto1Dy,c.MuFilter.Veto1Dz = 40.8*u.mm, 2798.3*u.mm, 192.1*u.mm
           c.MuFilter.Veto2Dx,c.MuFilter.Veto2Dy,c.MuFilter.Veto2Dz = 40.6*u.mm, 2839.3*u.mm, 172.1*u.mm
@@ -200,7 +200,6 @@ with ConfigRegistry.register_config("basic") as c:
 
         # relation between edge and bottom bar for VETO
         c.MuFilter.VETOLocX,c.MuFilter.VETOLocY,c.MuFilter.VETOLocZ = 20.0*u.mm,20.0*u.mm,46.7*u.mm
-        c.MuFilter.VETOLocX3,c.MuFilter.VETOLocY3,c.MuFilter.VETOLocZ3 = 20.0*u.mm, 20.0*u.mm, 14.0*u.mm
 
         # relation between edge and bottom bar for US and DS
         c.MuFilter.DSHLocX,c.MuFilter.DSHLocY,c.MuFilter.DSHLocZ      = 10.5*u.mm, 32.0*u.mm, 11.1*u.mm
@@ -265,25 +264,25 @@ with ConfigRegistry.register_config("basic") as c:
         c.MuFilter.SupportBoxVW = 4*u.mm
         c.MuFilter.SupportBoxVDH = 0*u.mm
         if year == 2024:
-          c.MuFilter.SupportBoxVW = 6*u.mm # FIXME
+          c.MuFilter.SupportBoxVB3 = 6*u.mm
           c.MuFilter.SupportBoxVDH  = 2.0*u.mm  # empty space between 3rd veto plane and box (left-right sides in the hor. plane)
         c.MuFilter.VETOBoxX1        = c.MuFilter.VETOLocX - c.MuFilter.SupportBoxD
         c.MuFilter.VETOBoxX2        = c.MuFilter.VETOLocX + c.MuFilter.VetoBarX + c.MuFilter.SupportBoxD
         
-        c.MuFilter.VETOBoxX3        = c.MuFilter.VETOLocX3 - c.MuFilter.Veto3BarX/2 - c.MuFilter.SupportBoxD - c.MuFilter.SupportBoxVDH
-        c.MuFilter.VETOBoxX4        = c.MuFilter.VETOLocX3 + (c.MuFilter.NVetoBars-1)*(c.MuFilter.Veto3BarX+c.MuFilter.VetoBarGap) + c.MuFilter.Veto3BarX/2 + c.MuFilter.SupportBoxD + c.MuFilter.SupportBoxVDH
+        c.MuFilter.VETOBoxX3        = - c.MuFilter.Veto3BarX/2 - c.MuFilter.SupportBoxD - c.MuFilter.SupportBoxVDH
+        c.MuFilter.VETOBoxX4        = (c.MuFilter.NVetoBars-1)*(c.MuFilter.Veto3BarX+c.MuFilter.VetoBarGap) + c.MuFilter.Veto3BarX/2 + c.MuFilter.SupportBoxD + c.MuFilter.SupportBoxVDH
         
         c.MuFilter.VETOBoxZ1        = c.MuFilter.VETOLocZ - c.MuFilter.VetoBarY/2 - c.MuFilter.SupportBoxD
         c.MuFilter.VETOBoxZ2        = c.MuFilter.VETOLocZ + (c.MuFilter.NVetoBars-1)*(c.MuFilter.VetoBarY+c.MuFilter.VetoBarGap) + c.MuFilter.VetoBarY/2 + c.MuFilter.SupportBoxD
         
-        c.MuFilter.VETOBoxZ3        = c.MuFilter.VETOLocZ3 - c.MuFilter.SupportBoxD 
-        c.MuFilter.VETOBoxZ4        = c.MuFilter.VETOLocZ3 + c.MuFilter.Veto3BarY + c.MuFilter.SupportBoxD
+        c.MuFilter.VETOBoxZ3        = - c.MuFilter.SupportBoxD 
+        c.MuFilter.VETOBoxZ4        = c.MuFilter.Veto3BarY + c.MuFilter.SupportBoxD
         
         c.MuFilter.VETOBoxY1        = c.MuFilter.VETOLocY - c.MuFilter.VetoBarZ/2 - c.MuFilter.SupportBoxD
         c.MuFilter.VETOBoxY2        = c.MuFilter.VETOLocY + c.MuFilter.VetoBarZ/2 + c.MuFilter.SupportBoxD
         
-        c.MuFilter.VETOBoxY3        = c.MuFilter.VETOLocY3 - c.MuFilter.Veto3BarZ/2 - c.MuFilter.SupportBoxD
-        c.MuFilter.VETOBoxY4        = c.MuFilter.VETOLocY3 + c.MuFilter.Veto3BarZ/2 + c.MuFilter.SupportBoxD
+        c.MuFilter.VETOBoxY3        = - c.MuFilter.Veto3BarZ/2 - c.MuFilter.SupportBoxD
+        c.MuFilter.VETOBoxY4        = c.MuFilter.Veto3BarZ/2 + c.MuFilter.SupportBoxD
 
        # VETO/US/DS plane alignment
         c.MuFilter.Veto1ShiftY =  0.11 * u.cm

--- a/geometry/sndLHC_TI18geom_config.py
+++ b/geometry/sndLHC_TI18geom_config.py
@@ -290,6 +290,14 @@ with ConfigRegistry.register_config("basic") as c:
         c.Floor.DX = 1.0*u.cm 
         c.Floor.DY = -4.5*u.cm #  subtract 4.5cm to avoid overlaps 
         c.Floor.DZ = 0.
+        
+        # Pit on the tunnel floor hosting Veto - using survey coord. system
+        # Dimensions
+        c.Floor.VetoPitXdim, c.Floor.VetoPitYdim, c.Floor.VetoPitZdim = 500*u.mm, 200*u.mm, 86*u.mm
+        # Position == Emuslion wall 1 + a correction in Z
+        c.Floor.VetoPitX =  c.EmulsionDet.Xpos0
+        c.Floor.VetoPitY =  c.EmulsionDet.Ypos0
+        c.Floor.VetoPitZ =  c.EmulsionDet.Zpos0 + c.EmulsionDet.WallZBorder_offset
 
         #COLDBOX configuration
         c.Floor.Acrylic_width = 5.0*u.cm

--- a/geometry/sndLHC_TI18geom_config.py
+++ b/geometry/sndLHC_TI18geom_config.py
@@ -160,6 +160,7 @@ with ConfigRegistry.register_config("basic") as c:
         #coordinates in local gravity based system
         c.MuFilter.Veto1Dx,c.MuFilter.Veto1Dy,c.MuFilter.Veto1Dz = 40.8*u.mm, 2798.3*u.mm, 192.1*u.mm
         c.MuFilter.Veto2Dx,c.MuFilter.Veto2Dy,c.MuFilter.Veto2Dz = 40.6*u.mm, 2839.3*u.mm, 172.1*u.mm       
+        c.MuFilter.Veto3Dx,c.MuFilter.Veto3Dy,c.MuFilter.Veto3Dz = 40.6*u.mm, 2879.3*u.mm, 152.1*u.mm
         c.MuFilter.Iron1Dx, c.MuFilter.Iron1Dy, c.MuFilter.Iron1Dz = -22.1*u.mm, 3579.6*u.mm, 146.6*u.mm   
         # US1
         c.MuFilter.Muon1Dx,c.MuFilter.Muon1Dy,c.MuFilter.Muon1Dz = -46.6*u.mm, 3760.2*u.mm, 128.6 *u.mm  
@@ -192,6 +193,7 @@ with ConfigRegistry.register_config("basic") as c:
 
         # relation between edge and bottom bar for VETO
         c.MuFilter.VETOLocX,c.MuFilter.VETOLocY,c.MuFilter.VETOLocZ = 20.0*u.mm,20.0*u.mm,46.7*u.mm
+        c.MuFilter.VETOLocX3,c.MuFilter.VETOLocY3,c.MuFilter.VETOLocZ3 = 20.0*u.mm, 20.0*u.mm, 46.7*u.mm
 
         # relation between edge and bottom bar for US and DS
         c.MuFilter.DSHLocX,c.MuFilter.DSHLocY,c.MuFilter.DSHLocZ      = 10.5*u.mm, 32.0*u.mm, 11.1*u.mm
@@ -208,10 +210,11 @@ with ConfigRegistry.register_config("basic") as c:
         #Veto station parameters
         c.MuFilter.VetonSiPMs = 8
         c.MuFilter.VetonSides  = 2
-        c.MuFilter.NVetoPlanes = 2
+        c.MuFilter.NVetoPlanes = 3
         c.MuFilter.NVetoBars    = 7
 
         c.MuFilter.VetoBarX,c.MuFilter.VetoBarY,c.MuFilter.VetoBarZ = 42 *u.cm, 6 * u.cm, 1 * u.cm
+        c.MuFilter.Veto3BarX,c.MuFilter.Veto3BarY,c.MuFilter.Veto3BarZ = 6*u.cm, 46*u.cm, 1*u.cm
         c.MuFilter.VetoBarGap = 2*30*u.um  # wrapping material
 
         c.MuFilter.FeX,c.MuFilter.FeY,c.MuFilter.FeZ                  = 80*u.cm, 60*u.cm, 20*u.cm
@@ -254,14 +257,26 @@ with ConfigRegistry.register_config("basic") as c:
         c.MuFilter.SupportBoxVW = 4*u.mm
         c.MuFilter.VETOBoxX1        = c.MuFilter.VETOLocX - c.MuFilter.SupportBoxD
         c.MuFilter.VETOBoxX2        = c.MuFilter.VETOLocX + c.MuFilter.VetoBarX + c.MuFilter.SupportBoxD
+        
+        c.MuFilter.VETOBoxX3        = c.MuFilter.VETOLocX - c.MuFilter.Veto3BarX/2 - c.MuFilter.SupportBoxD
+        c.MuFilter.VETOBoxX4        = c.MuFilter.VETOLocX + (c.MuFilter.NVetoBars-1)*(c.MuFilter.Veto3BarX+c.MuFilter.VetoBarGap) + c.MuFilter.Veto3BarX/2 + c.MuFilter.SupportBoxD
+        
         c.MuFilter.VETOBoxZ1        = c.MuFilter.VETOLocZ - c.MuFilter.VetoBarY/2 - c.MuFilter.SupportBoxD
         c.MuFilter.VETOBoxZ2        = c.MuFilter.VETOLocZ + (c.MuFilter.NVetoBars-1)*(c.MuFilter.VetoBarY+c.MuFilter.VetoBarGap) + c.MuFilter.VetoBarY/2 + c.MuFilter.SupportBoxD
+        
+        c.MuFilter.VETOBoxZ3        = c.MuFilter.VETOLocZ - c.MuFilter.SupportBoxD
+        c.MuFilter.VETOBoxZ4        = c.MuFilter.VETOLocZ + c.MuFilter.Veto3BarY + c.MuFilter.SupportBoxD
+
         c.MuFilter.VETOBoxY1        = c.MuFilter.VETOLocY - c.MuFilter.VetoBarZ/2 - c.MuFilter.SupportBoxD
         c.MuFilter.VETOBoxY2        = c.MuFilter.VETOLocY + c.MuFilter.VetoBarZ/2 + c.MuFilter.SupportBoxD
+
+        c.MuFilter.VETOBoxY3        = c.MuFilter.VETOLocY - c.MuFilter.Veto3BarZ/2 - c.MuFilter.SupportBoxD
+        c.MuFilter.VETOBoxY4        = c.MuFilter.VETOLocY + c.MuFilter.Veto3BarZ/2 + c.MuFilter.SupportBoxD
 
        # VETO/US/DS plane alignment
         c.MuFilter.Veto1ShiftY =  0.11 * u.cm
         c.MuFilter.Veto2ShiftY =  -0.04 * u.cm
+        c.MuFilter.Veto3ShiftY =  0.0 * u.cm
         c.MuFilter.US1ShiftY =   0.10 * u.cm
         c.MuFilter.US2ShiftY =   0.26 * u.cm
         c.MuFilter.US3ShiftY =   0.24 * u.cm

--- a/geometry/sndLHC_TI18geom_config.py
+++ b/geometry/sndLHC_TI18geom_config.py
@@ -200,7 +200,7 @@ with ConfigRegistry.register_config("basic") as c:
 
         # relation between edge and bottom bar for VETO
         c.MuFilter.VETOLocX,c.MuFilter.VETOLocY,c.MuFilter.VETOLocZ = 20.0*u.mm,20.0*u.mm,46.7*u.mm
-        c.MuFilter.VETOLocX3,c.MuFilter.VETOLocY3,c.MuFilter.VETOLocZ3 = 20.0*u.mm, 20.0*u.mm, 46.7*u.mm
+        c.MuFilter.VETOLocX3,c.MuFilter.VETOLocY3,c.MuFilter.VETOLocZ3 = 20.0*u.mm, 20.0*u.mm, 14.0*u.mm
 
         # relation between edge and bottom bar for US and DS
         c.MuFilter.DSHLocX,c.MuFilter.DSHLocY,c.MuFilter.DSHLocZ      = 10.5*u.mm, 32.0*u.mm, 11.1*u.mm
@@ -222,7 +222,7 @@ with ConfigRegistry.register_config("basic") as c:
         c.MuFilter.NVetoBars    = 7
 
         c.MuFilter.VetoBarX,c.MuFilter.VetoBarY,c.MuFilter.VetoBarZ = 42 *u.cm, 6 * u.cm, 1 * u.cm
-        c.MuFilter.Veto3BarX,c.MuFilter.Veto3BarY,c.MuFilter.Veto3BarZ = 6*u.cm, 46*u.cm, 1*u.cm
+        c.MuFilter.Veto3BarX,c.MuFilter.Veto3BarY,c.MuFilter.Veto3BarZ = 5.94*u.cm, 46*u.cm, 1*u.cm
         c.MuFilter.VetoBarGap = 2*30*u.um  # wrapping material
 
         c.MuFilter.FeX,c.MuFilter.FeY,c.MuFilter.FeZ                  = 80*u.cm, 60*u.cm, 20*u.cm
@@ -263,23 +263,27 @@ with ConfigRegistry.register_config("basic") as c:
 
        # VETO support box 
         c.MuFilter.SupportBoxVW = 4*u.mm
+        c.MuFilter.SupportBoxVDH = 0*u.mm
         if year == 2024:
           c.MuFilter.SupportBoxVW = 6*u.mm # FIXME
+          c.MuFilter.SupportBoxVDH  = 2.0*u.mm  # empty space between 3rd veto plane and box (left-right sides in the hor. plane)
         c.MuFilter.VETOBoxX1        = c.MuFilter.VETOLocX - c.MuFilter.SupportBoxD
         c.MuFilter.VETOBoxX2        = c.MuFilter.VETOLocX + c.MuFilter.VetoBarX + c.MuFilter.SupportBoxD
         
-        c.MuFilter.VETOBoxX3        = c.MuFilter.VETOLocX - c.MuFilter.Veto3BarX/2 - c.MuFilter.SupportBoxD
-        c.MuFilter.VETOBoxX4        = c.MuFilter.VETOLocX + (c.MuFilter.NVetoBars-1)*(c.MuFilter.Veto3BarX+c.MuFilter.VetoBarGap) + c.MuFilter.Veto3BarX/2 + c.MuFilter.SupportBoxD
+        c.MuFilter.VETOBoxX3        = c.MuFilter.VETOLocX3 - c.MuFilter.Veto3BarX/2 - c.MuFilter.SupportBoxD - c.MuFilter.SupportBoxVDH
+        c.MuFilter.VETOBoxX4        = c.MuFilter.VETOLocX3 + (c.MuFilter.NVetoBars-1)*(c.MuFilter.Veto3BarX+c.MuFilter.VetoBarGap) + c.MuFilter.Veto3BarX/2 + c.MuFilter.SupportBoxD + c.MuFilter.SupportBoxVDH
         
         c.MuFilter.VETOBoxZ1        = c.MuFilter.VETOLocZ - c.MuFilter.VetoBarY/2 - c.MuFilter.SupportBoxD
         c.MuFilter.VETOBoxZ2        = c.MuFilter.VETOLocZ + (c.MuFilter.NVetoBars-1)*(c.MuFilter.VetoBarY+c.MuFilter.VetoBarGap) + c.MuFilter.VetoBarY/2 + c.MuFilter.SupportBoxD
         
-        c.MuFilter.VETOBoxZ3        = c.MuFilter.VETOLocZ - c.MuFilter.SupportBoxD
-        c.MuFilter.VETOBoxZ4        = c.MuFilter.VETOLocZ + c.MuFilter.Veto3BarY + c.MuFilter.SupportBoxD
+        c.MuFilter.VETOBoxZ3        = c.MuFilter.VETOLocZ3 - c.MuFilter.SupportBoxD 
+        c.MuFilter.VETOBoxZ4        = c.MuFilter.VETOLocZ3 + c.MuFilter.Veto3BarY + c.MuFilter.SupportBoxD
+        
         c.MuFilter.VETOBoxY1        = c.MuFilter.VETOLocY - c.MuFilter.VetoBarZ/2 - c.MuFilter.SupportBoxD
         c.MuFilter.VETOBoxY2        = c.MuFilter.VETOLocY + c.MuFilter.VetoBarZ/2 + c.MuFilter.SupportBoxD
-        c.MuFilter.VETOBoxY3        = c.MuFilter.VETOLocY - c.MuFilter.Veto3BarZ/2 - c.MuFilter.SupportBoxD
-        c.MuFilter.VETOBoxY4        = c.MuFilter.VETOLocY + c.MuFilter.Veto3BarZ/2 + c.MuFilter.SupportBoxD
+        
+        c.MuFilter.VETOBoxY3        = c.MuFilter.VETOLocY3 - c.MuFilter.Veto3BarZ/2 - c.MuFilter.SupportBoxD
+        c.MuFilter.VETOBoxY4        = c.MuFilter.VETOLocY3 + c.MuFilter.Veto3BarZ/2 + c.MuFilter.SupportBoxD
 
        # VETO/US/DS plane alignment
         c.MuFilter.Veto1ShiftY =  0.11 * u.cm

--- a/geometry/sndLHC_geom_config.py
+++ b/geometry/sndLHC_geom_config.py
@@ -6,6 +6,8 @@ if "nuTargetPassive" not in globals():
     nuTargetPassive = True
 if "useNagoyaEmulsions" not in globals():
     useNagoyaEmulsions=False
+if "year" in globals():
+    year = int(globals()["year"])
 
 with ConfigRegistry.register_config("basic") as c:
 # cave parameters
@@ -166,8 +168,15 @@ with ConfigRegistry.register_config("basic") as c:
 
         c.MuFilter = AttrDict(z=0*u.cm)
         #coordinates in local gravity based system
-        c.MuFilter.Veto1Dx,c.MuFilter.Veto1Dy,c.MuFilter.Veto1Dz = 40.8*u.mm, 2798.3*u.mm, 192.1*u.mm
-        c.MuFilter.Veto2Dx,c.MuFilter.Veto2Dy,c.MuFilter.Veto2Dz = 40.6*u.mm, 2839.3*u.mm, 172.1*u.mm       
+#coordinates in local gravity based system
+        if year == 2024:
+          c.MuFilter.Veto1Dx,c.MuFilter.Veto1Dy,c.MuFilter.Veto1Dz = 40.8*u.mm, 2761.2*u.mm, 164.3*u.mm
+          c.MuFilter.Veto2Dx,c.MuFilter.Veto2Dy,c.MuFilter.Veto2Dz = 40.6*u.mm, 2802.2*u.mm, 144.3*u.mm
+          c.MuFilter.Veto3Dx,c.MuFilter.Veto3Dy,c.MuFilter.Veto3Dz = 40.4*u.mm, 2843.3*u.mm, 125.8*u.mm
+        else:
+          c.MuFilter.Veto1Dx,c.MuFilter.Veto1Dy,c.MuFilter.Veto1Dz = 40.8*u.mm, 2798.3*u.mm, 192.1*u.mm
+          c.MuFilter.Veto2Dx,c.MuFilter.Veto2Dy,c.MuFilter.Veto2Dz = 40.6*u.mm, 2839.3*u.mm, 172.1*u.mm
+
         c.MuFilter.Iron1Dx, c.MuFilter.Iron1Dy, c.MuFilter.Iron1Dz = -22.1*u.mm, 3579.6*u.mm, 146.6*u.mm   
         # US1
         c.MuFilter.Muon1Dx,c.MuFilter.Muon1Dy,c.MuFilter.Muon1Dz = -46.6*u.mm, 3760.2*u.mm, 128.6 *u.mm  
@@ -216,7 +225,8 @@ with ConfigRegistry.register_config("basic") as c:
         #Veto station parameters
         c.MuFilter.VetonSiPMs = 8
         c.MuFilter.VetonSides  = 2
-        c.MuFilter.NVetoPlanes = 2
+        if year == 2024: c.MuFilter.NVetoPlanes = 3
+        else: c.MuFilter.NVetoPlanes = 2
         c.MuFilter.NVetoBars    = 7
 
         c.MuFilter.VetoBarX,c.MuFilter.VetoBarY,c.MuFilter.VetoBarZ = 42 *u.cm, 6 * u.cm, 1 * u.cm
@@ -260,6 +270,9 @@ with ConfigRegistry.register_config("basic") as c:
 
        # VETO support box
         c.MuFilter.SupportBoxVW = 4*u.mm
+        if year == 2024:
+          c.MuFilter.SupportBoxVW = 6*u.mm # FIXME
+
         c.MuFilter.VETOBoxX1        = c.MuFilter.VETOLocX - c.MuFilter.SupportBoxD
         c.MuFilter.VETOBoxX2        = c.MuFilter.VETOLocX + c.MuFilter.VetoBarX + c.MuFilter.SupportBoxD
         c.MuFilter.VETOBoxZ1        = c.MuFilter.VETOLocZ - c.MuFilter.VetoBarY/2 - c.MuFilter.SupportBoxD
@@ -298,6 +311,15 @@ with ConfigRegistry.register_config("basic") as c:
         c.Floor.DX = 1.0*u.cm 
         c.Floor.DY = -4.5*u.cm #  subtract 4.5cm to avoid overlaps 
         c.Floor.DZ = 0.
+
+        if year == 2024:
+          # Pit on the tunnel floor hosting Veto - using survey coord. system
+          # Dimensions
+          c.Floor.VetoPitXdim, c.Floor.VetoPitYdim, c.Floor.VetoPitZdim = 500*u.mm, 200*u.mm, 86*u.mm
+          # Position == Emuslion wall 1 + a correction in Z
+          c.Floor.VetoPitX =  c.EmulsionDet.Xpos0
+          c.Floor.VetoPitY =  c.EmulsionDet.Ypos0
+          c.Floor.VetoPitZ =  c.EmulsionDet.Zpos0 + c.EmulsionDet.WallZBorder_offset
 
         #COLDBOX configuration
         c.Floor.Acrylic_width = 5.0*u.cm

--- a/geometry/sndLHC_geom_config.py
+++ b/geometry/sndLHC_geom_config.py
@@ -209,6 +209,8 @@ with ConfigRegistry.register_config("basic") as c:
 
         # relation between edge and bottom bar for VETO
         c.MuFilter.VETOLocX,c.MuFilter.VETOLocY,c.MuFilter.VETOLocZ = 20.0*u.mm,20.0*u.mm,46.7*u.mm
+        c.MuFilter.VETOLocX3,c.MuFilter.VETOLocY3,c.MuFilter.VETOLocZ3 = 20.0*u.mm,20.0*u.mm,14.0*u.mm
+
 
         # relation between edge and bottom bar for US and DS
         c.MuFilter.DSHLocX,c.MuFilter.DSHLocY,c.MuFilter.DSHLocZ      = 10.5*u.mm, 32.0*u.mm, 11.1*u.mm
@@ -230,6 +232,7 @@ with ConfigRegistry.register_config("basic") as c:
         c.MuFilter.NVetoBars    = 7
 
         c.MuFilter.VetoBarX,c.MuFilter.VetoBarY,c.MuFilter.VetoBarZ = 42 *u.cm, 6 * u.cm, 1 * u.cm
+        c.MuFilter.Veto3BarX,c.MuFilter.Veto3BarY,c.MuFilter.Veto3BarZ = 5.94*u.cm, 46*u.cm, 1*u.cm
         c.MuFilter.VetoBarGap = 2*30*u.um  # wrapping material
 
         c.MuFilter.FeX,c.MuFilter.FeY,c.MuFilter.FeZ                  = 80*u.cm, 60*u.cm, 20*u.cm
@@ -270,19 +273,33 @@ with ConfigRegistry.register_config("basic") as c:
 
        # VETO support box
         c.MuFilter.SupportBoxVW = 4*u.mm
+        c.MuFilter.SupportBoxVDH = 0*u.mm
         if year == 2024:
           c.MuFilter.SupportBoxVW = 6*u.mm # FIXME
+          c.MuFilter.SupportBoxVDH  = 2.0*u.mm  # empty space between 3rd veto plane and box (left-right sides in the hor. plane)
 
         c.MuFilter.VETOBoxX1        = c.MuFilter.VETOLocX - c.MuFilter.SupportBoxD
         c.MuFilter.VETOBoxX2        = c.MuFilter.VETOLocX + c.MuFilter.VetoBarX + c.MuFilter.SupportBoxD
+        
+        c.MuFilter.VETOBoxX3        = c.MuFilter.VETOLocX3 - c.MuFilter.Veto3BarX/2 - c.MuFilter.SupportBoxD - c.MuFilter.SupportBoxVDH
+        c.MuFilter.VETOBoxX4        = c.MuFilter.VETOLocX3 + (c.MuFilter.NVetoBars-1)*(c.MuFilter.Veto3BarX+c.MuFilter.VetoBarGap) + c.MuFilter.Veto3BarX/2 + c.MuFilter.SupportBoxD + c.MuFilter.SupportBoxVDH
+        
         c.MuFilter.VETOBoxZ1        = c.MuFilter.VETOLocZ - c.MuFilter.VetoBarY/2 - c.MuFilter.SupportBoxD
         c.MuFilter.VETOBoxZ2        = c.MuFilter.VETOLocZ + (c.MuFilter.NVetoBars-1)*(c.MuFilter.VetoBarY+c.MuFilter.VetoBarGap) + c.MuFilter.VetoBarY/2 + c.MuFilter.SupportBoxD
+        
+        c.MuFilter.VETOBoxZ3        = c.MuFilter.VETOLocZ3 - c.MuFilter.SupportBoxD
+        c.MuFilter.VETOBoxZ4        = c.MuFilter.VETOLocZ3 + c.MuFilter.Veto3BarY + c.MuFilter.SupportBoxD
+        
         c.MuFilter.VETOBoxY1        = c.MuFilter.VETOLocY - c.MuFilter.VetoBarZ/2 - c.MuFilter.SupportBoxD
         c.MuFilter.VETOBoxY2        = c.MuFilter.VETOLocY + c.MuFilter.VetoBarZ/2 + c.MuFilter.SupportBoxD
+        
+        c.MuFilter.VETOBoxY3        = c.MuFilter.VETOLocY3 - c.MuFilter.Veto3BarZ/2 - c.MuFilter.SupportBoxD
+        c.MuFilter.VETOBoxY4        = c.MuFilter.VETOLocY3 + c.MuFilter.Veto3BarZ/2 + c.MuFilter.SupportBoxD
 
        # VETO/US/DS plane alignment
         c.MuFilter.Veto1ShiftY = 0 * u.cm
         c.MuFilter.Veto2ShiftY = 0 * u.cm
+        c.MuFilter.Veto3ShiftY = 0 * u.cm
         c.MuFilter.US1ShiftY =   0 * u.cm
         c.MuFilter.US2ShiftY =   0 * u.cm
         c.MuFilter.US3ShiftY =   0 * u.cm

--- a/geometry/sndLHC_geom_config.py
+++ b/geometry/sndLHC_geom_config.py
@@ -170,9 +170,9 @@ with ConfigRegistry.register_config("basic") as c:
         #coordinates in local gravity based system
 #coordinates in local gravity based system
         if year == 2024:
-          c.MuFilter.Veto1Dx,c.MuFilter.Veto1Dy,c.MuFilter.Veto1Dz = 40.8*u.mm, 2761.2*u.mm, 164.3*u.mm
-          c.MuFilter.Veto2Dx,c.MuFilter.Veto2Dy,c.MuFilter.Veto2Dz = 40.6*u.mm, 2802.2*u.mm, 144.3*u.mm
-          c.MuFilter.Veto3Dx,c.MuFilter.Veto3Dy,c.MuFilter.Veto3Dz = 40.4*u.mm, 2843.3*u.mm, 125.8*u.mm
+          c.MuFilter.Veto1Dx,c.MuFilter.Veto1Dy,c.MuFilter.Veto1Dz = 49.3*u.mm, 2761.1*u.mm, 168.1*u.mm
+          c.MuFilter.Veto2Dx,c.MuFilter.Veto2Dy,c.MuFilter.Veto2Dz = 49.3*u.mm, 2802.1*u.mm, 148.1*u.mm
+          c.MuFilter.Veto3Dx,c.MuFilter.Veto3Dy,c.MuFilter.Veto3Dz = 61.8*u.mm, 2863.1*u.mm, 146.6*u.mm
         else:
           c.MuFilter.Veto1Dx,c.MuFilter.Veto1Dy,c.MuFilter.Veto1Dz = 40.8*u.mm, 2798.3*u.mm, 192.1*u.mm
           c.MuFilter.Veto2Dx,c.MuFilter.Veto2Dy,c.MuFilter.Veto2Dz = 40.6*u.mm, 2839.3*u.mm, 172.1*u.mm
@@ -209,8 +209,6 @@ with ConfigRegistry.register_config("basic") as c:
 
         # relation between edge and bottom bar for VETO
         c.MuFilter.VETOLocX,c.MuFilter.VETOLocY,c.MuFilter.VETOLocZ = 20.0*u.mm,20.0*u.mm,46.7*u.mm
-        c.MuFilter.VETOLocX3,c.MuFilter.VETOLocY3,c.MuFilter.VETOLocZ3 = 20.0*u.mm,20.0*u.mm,14.0*u.mm
-
 
         # relation between edge and bottom bar for US and DS
         c.MuFilter.DSHLocX,c.MuFilter.DSHLocY,c.MuFilter.DSHLocZ      = 10.5*u.mm, 32.0*u.mm, 11.1*u.mm
@@ -275,26 +273,26 @@ with ConfigRegistry.register_config("basic") as c:
         c.MuFilter.SupportBoxVW = 4*u.mm
         c.MuFilter.SupportBoxVDH = 0*u.mm
         if year == 2024:
-          c.MuFilter.SupportBoxVW = 6*u.mm # FIXME
+          c.MuFilter.SupportBoxVB3 = 6*u.mm
           c.MuFilter.SupportBoxVDH  = 2.0*u.mm  # empty space between 3rd veto plane and box (left-right sides in the hor. plane)
 
         c.MuFilter.VETOBoxX1        = c.MuFilter.VETOLocX - c.MuFilter.SupportBoxD
         c.MuFilter.VETOBoxX2        = c.MuFilter.VETOLocX + c.MuFilter.VetoBarX + c.MuFilter.SupportBoxD
         
-        c.MuFilter.VETOBoxX3        = c.MuFilter.VETOLocX3 - c.MuFilter.Veto3BarX/2 - c.MuFilter.SupportBoxD - c.MuFilter.SupportBoxVDH
-        c.MuFilter.VETOBoxX4        = c.MuFilter.VETOLocX3 + (c.MuFilter.NVetoBars-1)*(c.MuFilter.Veto3BarX+c.MuFilter.VetoBarGap) + c.MuFilter.Veto3BarX/2 + c.MuFilter.SupportBoxD + c.MuFilter.SupportBoxVDH
+        c.MuFilter.VETOBoxX3        = - c.MuFilter.Veto3BarX/2 - c.MuFilter.SupportBoxD - c.MuFilter.SupportBoxVDH
+        c.MuFilter.VETOBoxX4        = (c.MuFilter.NVetoBars-1)*(c.MuFilter.Veto3BarX+c.MuFilter.VetoBarGap) + c.MuFilter.Veto3BarX/2 + c.MuFilter.SupportBoxD + c.MuFilter.SupportBoxVDH
         
         c.MuFilter.VETOBoxZ1        = c.MuFilter.VETOLocZ - c.MuFilter.VetoBarY/2 - c.MuFilter.SupportBoxD
         c.MuFilter.VETOBoxZ2        = c.MuFilter.VETOLocZ + (c.MuFilter.NVetoBars-1)*(c.MuFilter.VetoBarY+c.MuFilter.VetoBarGap) + c.MuFilter.VetoBarY/2 + c.MuFilter.SupportBoxD
         
-        c.MuFilter.VETOBoxZ3        = c.MuFilter.VETOLocZ3 - c.MuFilter.SupportBoxD
-        c.MuFilter.VETOBoxZ4        = c.MuFilter.VETOLocZ3 + c.MuFilter.Veto3BarY + c.MuFilter.SupportBoxD
+        c.MuFilter.VETOBoxZ3        = - c.MuFilter.SupportBoxD
+        c.MuFilter.VETOBoxZ4        = c.MuFilter.Veto3BarY + c.MuFilter.SupportBoxD
         
         c.MuFilter.VETOBoxY1        = c.MuFilter.VETOLocY - c.MuFilter.VetoBarZ/2 - c.MuFilter.SupportBoxD
         c.MuFilter.VETOBoxY2        = c.MuFilter.VETOLocY + c.MuFilter.VetoBarZ/2 + c.MuFilter.SupportBoxD
         
-        c.MuFilter.VETOBoxY3        = c.MuFilter.VETOLocY3 - c.MuFilter.Veto3BarZ/2 - c.MuFilter.SupportBoxD
-        c.MuFilter.VETOBoxY4        = c.MuFilter.VETOLocY3 + c.MuFilter.Veto3BarZ/2 + c.MuFilter.SupportBoxD
+        c.MuFilter.VETOBoxY3        = - c.MuFilter.Veto3BarZ/2 - c.MuFilter.SupportBoxD
+        c.MuFilter.VETOBoxY4        = c.MuFilter.Veto3BarZ/2 + c.MuFilter.SupportBoxD
 
        # VETO/US/DS plane alignment
         c.MuFilter.Veto1ShiftY = 0 * u.cm

--- a/python/shipunit.py
+++ b/python/shipunit.py
@@ -317,5 +317,7 @@ kGasThreshold   = 10.*mg/cm3
 universe_mean_density = 1.e-25*g/cm3
 #
 speedOfLight = 299792458*m/s
-
+# specific SNDLHC constants
+snd_freq   = 160.316*megahertz # sndlhc clock
+snd_TDC2ns = (1E9/freq)*ns
 

--- a/shipLHC/Floor.cxx
+++ b/shipLHC/Floor.cxx
@@ -357,7 +357,20 @@ void Floor::ConstructGeometry()
 
   }
   LOG(DEBUG) << "shapes "<<shapes[0]->GetName()<<" "<<shapes[1]->GetName()<<" "<<shapes[2]->GetName();
-  auto total = new TGeoCompositeShape("Stotal","TI18_1_union+TI18_2_union+TI18_3_union");
+
+  // Since 2024 there is a pit on the TI18 floor hosting the veto
+  // Unless defined in the geo config file, the pit dims are 0.
+  auto vetoPit = new TGeoBBox("vetoPit",
+                                 conf_floats["Floor/VetoPitXdim"]/2.,
+                                 conf_floats["Floor/VetoPitZdim"]/2.,
+                                 conf_floats["Floor/VetoPitYdim"]/2.);
+  auto VetoPit_transl = new TGeoTranslation("VetoPit_transl",
+                                -conf_floats["Floor/VetoPitX"]-conf_floats["Floor/VetoPitXdim"]/2.,
+                                 conf_floats["Floor/VetoPitZ"]-conf_floats["Floor/VetoPitZdim"]/2.,
+                                 conf_floats["Floor/VetoPitY"]-conf_floats["Floor/VetoPitYdim"]/2.);
+  VetoPit_transl->RegisterYourself();
+
+  auto total = new TGeoCompositeShape("Stotal","TI18_1_union+TI18_2_union+TI18_3_union-vetoPit:VetoPit_transl");
   auto volT = new TGeoVolume("VTI18",total,concrete);
   volT->SetTransparency(0);
   volT->SetLineColor(kGray);
@@ -427,6 +440,7 @@ void Floor::ConstructGeometry()
  auto bigBox   = new TGeoBBox("BigBox", 1000.,1000. , dz);
  auto TR_1       = new TGeoTranslation("TR_1",0.,0.,-dz+geoParameters["TI18_o1"][2]-SND_Z - 50.); // move a bit more upstream to have free view from the back
  TR_1->RegisterYourself();
+ 
  auto cutOut   = new TGeoCompositeShape("cutOut", "BigBox:TR_1-Ftotal2-(TI18_1_Funion+TI18_2_Funion+TI18_3_Funion)");
  auto volT3      = new TGeoVolume("Vrock",cutOut,rock);
  volT3->SetTransparency(75);

--- a/shipLHC/MuFilter.cxx
+++ b/shipLHC/MuFilter.cxx
@@ -716,9 +716,16 @@ void MuFilter::GetPosition(Int_t fDetectorID, TVector3& vLeft, TVector3& vRight)
    }
    Int_t MuFilter::GetnSides(Int_t detID){
        int subsystem     = floor(detID/10000)-1;
-       if (subsystem==0){return conf_ints["MuFilter/VetonSides"];}
+       if (subsystem==0){
+         // vertical Veto 3 has the readout on the top only
+         if (detID>=12000) return conf_ints["MuFilter/VetonSides"]-1;
+         else {return conf_ints["MuFilter/VetonSides"];}
+       }
        if (subsystem==1){return conf_ints["MuFilter/UpstreamnSides"];}
-       return conf_ints["MuFilter/DownstreamnSides"];
+       if (subsystem==2){
+          if (detID%1000>59) return conf_ints["MuFilter/DownstreamnSides"]-1;
+          else {return conf_ints["MuFilter/DownstreamnSides"];}
+       }
   }
 
 ClassImp(MuFilter)

--- a/shipLHC/MuFilter.cxx
+++ b/shipLHC/MuFilter.cxx
@@ -191,9 +191,11 @@ void MuFilter::ConstructGeometry()
 	Int_t fNVetoPlanes       = conf_ints["MuFilter/NVetoPlanes"];
 	Int_t fNVetoBars          = conf_ints["MuFilter/NVetoBars"];
 	Double_t fSupportBoxVW = conf_floats["MuFilter/SupportBoxVW"]; // SupportBox dimensions
+	// thickness of bottom part of Veto 3 SupportBox
+	Double_t fSupportBoxVB3 = conf_floats["MuFilter/SupportBoxVB3"];
 	// local position of bottom horizontal bar to survey edge
 	TVector3 LocBarVeto = TVector3(-conf_floats["MuFilter/VETOLocX"], conf_floats["MuFilter/VETOLocZ"],conf_floats["MuFilter/VETOLocY"]);
-	TVector3 LocBarVeto_v = TVector3(-conf_floats["MuFilter/VETOLocX3"], conf_floats["MuFilter/VETOLocZ3"],conf_floats["MuFilter/VETOLocY3"]);// FIXME check if it is correct
+	TVector3 LocBarVeto_v = TVector3(-conf_floats["MuFilter/VETOLocX3"], conf_floats["MuFilter/VETOLocZ3"],conf_floats["MuFilter/VETOLocY3"]);
 
 	TVector3 VetoBox1 = TVector3(-conf_floats["MuFilter/VETOBoxX1"],conf_floats["MuFilter/VETOBoxZ1"],conf_floats["MuFilter/VETOBoxY1"]); // bottom front left
 	TVector3 VetoBox2 = TVector3(-conf_floats["MuFilter/VETOBoxX2"],conf_floats["MuFilter/VETOBoxZ2"],conf_floats["MuFilter/VETOBoxY2"]); // top back right
@@ -211,7 +213,7 @@ void MuFilter::ConstructGeometry()
 	TVector3 Veto3BoxDim = TVector3( VetoBox3.X()-VetoBox4.X(), VetoBox4.Y()-VetoBox3.Y(), VetoBox4.Z()-VetoBox3.Z() ) ;
 	// support box
 	TGeoBBox  *supVeto3BoxInner  = new TGeoBBox("supVeto3BoxI",Veto3BoxDim.X()/2,Veto3BoxDim.Y()/2,Veto3BoxDim.Z()/2);
-	TGeoBBox  *supVeto3BoxOuter = new TGeoBBox("supVeto3BoxO",Veto3BoxDim.X()/2+fSupportBoxVW,Veto3BoxDim.Y()/2+fSupportBoxVW,Veto3BoxDim.Z()/2+fSupportBoxVW);
+	TGeoBBox  *supVeto3BoxOuter = new TGeoBBox("supVeto3BoxO",Veto3BoxDim.X()/2+fSupportBoxVW,Veto3BoxDim.Y()/2+fSupportBoxVB3,Veto3BoxDim.Z()/2+fSupportBoxVW);
 	TGeoCompositeShape *subVeto3BoxShape = new TGeoCompositeShape("subVeto3BoxShape", "supVeto3BoxO-supVeto3BoxI");
 	TGeoVolume *subVeto3Box = new TGeoVolume("subVeto3Box", subVeto3BoxShape, Al);     
 	subVeto3Box->SetLineColor(kGray+1);
@@ -261,7 +263,7 @@ void MuFilter::ConstructGeometry()
 
 	     displacement = TVector3(0, 0, 0);
 	     for (Int_t ibar = 0; ibar < fNVetoBars; ibar++){
-	       Double_t dx_bar =  (fVeto3BarX + fVetoBarGap)*ibar; //FIXME check what is the gap btw bars for 3rd Veto
+	       Double_t dx_bar =  (fVeto3BarX + fVetoBarGap)*ibar;
 	       volVetoPlane->AddNode(volVetoBar_ver, 1e+4+iplane*1e+3+ibar,
 				 new TGeoTranslation(displacement.X()-dx_bar,displacement.Y(),displacement.Z())); // detID of type 12xxx
 	     }

--- a/shipLHC/MuFilter.cxx
+++ b/shipLHC/MuFilter.cxx
@@ -323,12 +323,7 @@ void MuFilter::ConstructGeometry()
 	Double_t dz = 0;
 	//Upstream Detector planes definition
 	Double_t fUpstreamDetZ =  conf_floats["MuFilter/UpstreamDetZ"];
-	
-	/* For the testbeam 2023, there is no Veto detector. However, to have the correct mapping of US and DS bars,
-	   one needs to have the standatd NvetoPlanes=2
-	   It is safe to go back to 2 'fictional' Veto planes now, after the Veto construction part. */
-	if (fNVetoPlanes != 2) fNVetoPlanes = 2;
-	
+
 	// local position of bottom horizontal bar to survey edge
 	TVector3 LocBarUS = TVector3(
 		-conf_floats["MuFilter/DSHLocX"],

--- a/shipLHC/MuFilterHit.cxx
+++ b/shipLHC/MuFilterHit.cxx
@@ -43,8 +43,7 @@ MuFilterHit::MuFilterHit(Int_t detID, std::vector<MuFilterPoint*> V)
      MuFilter* MuFilterDet = dynamic_cast<MuFilter*> (gROOT->GetListOfGlobals()->FindObject("MuFilter"));
      // get parameters from the MuFilter detector for simulating the digitized information
      nSiPMs  = MuFilterDet->GetnSiPMs(detID);
-     if (floor(detID/10000)==3&&detID%1000>59) nSides = MuFilterDet->GetnSides(detID) - 1;
-     else nSides = MuFilterDet->GetnSides(detID);
+     nSides = MuFilterDet->GetnSides(detID);
 
      Float_t timeResol = MuFilterDet->GetConfParF("MuFilter/timeResol");
 

--- a/shipLHC/MuFilterHit.cxx
+++ b/shipLHC/MuFilterHit.cxx
@@ -58,7 +58,11 @@ MuFilterHit::MuFilterHit(Int_t detID, std::vector<MuFilterPoint*> V)
               propspeed = MuFilterDet->GetConfParF("MuFilter/DsPropSpeed");
      }
      else { 
-              attLength = MuFilterDet->GetConfParF("MuFilter/VandUpAttenuationLength");
+              if (floor(detID/10000)==1 && nSides==1){
+                 // top readout with mirror on bottom
+                 attLength = 2*MuFilterDet->GetConfParF("MuFilter/VandUpAttenuationLength");
+              }
+              else {attLength = MuFilterDet->GetConfParF("MuFilter/VandUpAttenuationLength");}
               siPMcalibration = MuFilterDet->GetConfParF("MuFilter/VandUpSiPMcalibration");
               siPMcalibrationS = MuFilterDet->GetConfParF("MuFilter/VandUpSiPMcalibrationS");
               propspeed = MuFilterDet->GetConfParF("MuFilter/VandUpPropSpeed");
@@ -98,7 +102,7 @@ MuFilterHit::MuFilterHit(Int_t detID, std::vector<MuFilterPoint*> V)
      // shortSiPM = {3,6,11,14,19,22,27,30,35,38,43,46,51,54,59,62,67,70,75,78}; - counting from 1!
      // In the SndlhcHit class the 'signals' array starts from 0.
      for (unsigned int j=0; j<nSiPMs; ++j){
-        if (j==2 or j==5){
+        if ( floor(detID/10000)==2 && (j==2 or j==5)){                 // only US has small SiPMs
            signals[j] = signalLeft/float(nSiPMs) * siPMcalibrationS;   // most simplest model, divide signal individually. Small SiPMS special
            times[j] = gRandom->Gaus(earliestToAL, timeResol);
         }else{

--- a/shipLHC/MuFilterHit.cxx
+++ b/shipLHC/MuFilterHit.cxx
@@ -133,7 +133,10 @@ Float_t MuFilterHit::GetEnergy()
 }
 
 bool MuFilterHit::isVertical(){
-  if  (floor(fDetectorID/10000)==3&&fDetectorID%1000>59) {return kTRUE;}
+  if  ( (floor(fDetectorID/10000)==3&&fDetectorID%1000>59) ||
+         (floor(fDetectorID/10000)==1&&int(fDetectorID/1000)%10==2) ) {  
+      return kTRUE;
+  }
   else{return kFALSE;}
 }
 

--- a/shipLHC/makeGeoFile.py
+++ b/shipLHC/makeGeoFile.py
@@ -10,11 +10,12 @@ parser = ArgumentParser()
 
 parser.add_argument("-c",   dest="config",   help="configuration file", required=True)
 parser.add_argument("-g",   dest="geofile",   help="geo file output name", required=True)
+parser.add_argument("-y",   dest="year",   help="specify the year to generate the respective TI18 detector setup", required=True)
 options = parser.parse_args()
 
 shipRoot_conf.configure(0)     # load basic libraries, prepare atexit for python
 
-snd_geo = ConfigRegistry.loadpy(options.config)
+snd_geo = ConfigRegistry.loadpy(options.config, year=options.year)
 
 # -----Create simulation run----------------------------------------
 run = ROOT.FairRunSim()

--- a/shipLHC/rawData/ConvRawData.py
+++ b/shipLHC/rawData/ConvRawData.py
@@ -252,6 +252,7 @@ class ConvRawDataPY(ROOT.FairTask):
        for s in range(1,3):
            for o in ['Left','Right']: 
               self.offMap['Veto_'+str(s)+o] =[10000 + (s-1)*1000+ 0,8,2]    # first channel, nSiPMs, nSides, from bottom to top
+       self.offMap['Veto_3Vert'] = [10000 + 2*1000+ 0,8,1]
        for s in range(1,6):
            for o in ['Left','Right']: 
               self.offMap['US_'+str(s)+o] =[20000 + (s-1)*1000+ 9,-8,2]     # from top to bottom

--- a/shipLHC/rawData/boardMappingParser.py
+++ b/shipLHC/rawData/boardMappingParser.py
@@ -40,7 +40,11 @@ def getBoardMapping(jsonString):
         
         # loops over the slots (the first is always left, the second always right)
         for i in range(2):
-          boardMapsNew['MuFilter'][bString][conf['slots'][i]] = f'Veto_{plane}{"Left" if i == 0 else "Right"}'
+          if int(plane) <3:
+            boardMapsNew['MuFilter'][bString][conf['slots'][i]] = f'Veto_{plane}{"Left" if i == 0 else "Right"}'
+          # The vertical Veto plane has one slot only
+          if int(plane) ==3 and i == 0: 
+            boardMapsNew['MuFilter'][bString][conf['slots'][i]] = f'Veto_{plane[i]}Vert'
 
     elif subsys == 'us':
       for plane, conf in planes.items():

--- a/shipLHC/run_simSND.py
+++ b/shipLHC/run_simSND.py
@@ -50,6 +50,7 @@ parser.add_argument("--debug",   dest="debug",   help="debugging mode, check for
 parser.add_argument("-D", "--display", dest="eventDisplay", help="store trajectories", required=False, action="store_true")
 parser.add_argument("--EmuDet","--nuTargetActive",dest="nuTargetPassive",help="activate emulsiondetector", required=False,action="store_false")
 parser.add_argument("--NagoyaEmu","--useNagoyaEmulsions",dest="useNagoyaEmulsions",help="use bricks of 57 Nagoya emulsion films instead of 60 Slavich", required=False,action="store_true")
+parser.add_argument("-y", dest="year", help="specify the year to generate the respective TI18 detector setup", required=False, type=int, default=2024)
 
 options = parser.parse_args()
 
@@ -113,7 +114,8 @@ elif options.testbeam2023:
 else:
   snd_geo = ConfigRegistry.loadpy("$SNDSW_ROOT/geometry/sndLHC_geom_config.py",
                                    nuTargetPassive = options.nuTargetPassive,
-                                   useNagoyaEmulsions = options.useNagoyaEmulsions)
+                                   useNagoyaEmulsions = options.useNagoyaEmulsions,
+                                   year=options.year)
 
 if simEngine == "PG": tag = simEngine + "_"+str(options.pID)+"-"+mcEngine
 else: tag = simEngine+"-"+mcEngine

--- a/shipLHC/scripts/2dEventDisplay.py
+++ b/shipLHC/scripts/2dEventDisplay.py
@@ -31,7 +31,6 @@ from argparse import ArgumentParser
 parser = ArgumentParser()
 parser.add_argument("-r", "--runNumber", dest="runNumber", help="run number", type=int,required=False)
 parser.add_argument("-p", "--path", dest="path", help="path to data file",required=False,default=os.environ["EOSSHIP"]+"/eos/experiment/sndlhc/convertedData/physics/2022/")
-parser.add_argument("-praw", "--pathRaw", dest="pathRaw", help="path to raw data file",required=False,default="/eos/experiment/sndlhc/raw_data/physics/2022/")
 parser.add_argument("-f", "--inputFile", dest="inputFile", help="input file data and MC",default="",required=False)
 parser.add_argument("-g", "--geoFile", dest="geoFile", help="geofile", default=os.environ["EOSSHIP"]+"/eos/experiment/sndlhc/convertedData/physics/2022/geofile_sndlhc_TI18_V0_2022.root")
 parser.add_argument("-P", "--partition", dest="partition", help="partition of data", type=int,required=False,default=-1)

--- a/shipLHC/scripts/2dEventDisplay.py
+++ b/shipLHC/scripts/2dEventDisplay.py
@@ -23,7 +23,6 @@ atexit.register(pyExit)
 
 
 A,B = ROOT.TVector3(),ROOT.TVector3()
-freq      =  160.316E6
 
 eventComment = {}   # possibility to add an event comment before moving to next event
 
@@ -72,7 +71,6 @@ with2Points = False  # plot start and end point of straw/bar
 mc = False
 
 firstScifi_z = 300 * u.cm
-TDC2ns = 1E9 / 160.316E6
 
 # Initialize FairLogger: set severity and verbosity
 logger = ROOT.FairLogger.GetLogger()
@@ -424,7 +422,7 @@ def loopEvents(
 
     #Do we still use these lines? Seems no. 
     #And for events having all negative QDCs minT[1] is returned empty and the display crashes.
-    #dTs = "%5.2Fns"%(dT/freq*1E9)
+    #dTs = "%5.2Fns"%(dT/u.snd_freq*1E9)
     # find detector which triggered
     #minT = firstTimeStamp(event)
     #dTs+= "    " + str(minT[1].GetDetectorID())
@@ -957,7 +955,7 @@ def timingOfEvent(makeCluster=False,debug=False):
           pos = (A[0]+B[0])/2.
           L = abs(A[1]-B[1])/2.
        for i in range(nmax):
-            corTime = geo.modules['MuFilter'].GetCorrectedTime(detID, i, aHit.GetTime(i)*TDC2ns, 0)- (z-firstScifi_z)/u.speedOfLight
+            corTime = geo.modules['MuFilter'].GetCorrectedTime(detID, i, aHit.GetTime(i)*u.snd_TDC2ns, 0)- (z-firstScifi_z)/u.speedOfLight
             h['evTimeDS'].Fill(corTime)
             if debug: print(detID,i,corTime,pos)
    tc=h['tevTime'].cd()

--- a/shipLHC/scripts/Monitor.py
+++ b/shipLHC/scripts/Monitor.py
@@ -72,14 +72,6 @@ class Monitoring():
         self.TEnd   = -1
         self.MonteCarlo = False
         self.Weight = 1
-# MuFilter mapping of planes and bars 
-        self.systemAndPlanes  = {1:2,2:5,3:7}
-        self.systemAndBars     = {1:7,2:10,3:60}
-        self.systemAndChannels     = {1:[8,0],2:[6,2],3:[1,0]}
-        self.sdict                     = {0:'Scifi',1:'Veto',2:'US',3:'DS'}
-
-        self.freq      =  160.316E6
-        self.TDC2ns = 1E9/self.freq
 
         path     = options.path
         self.myclient = None
@@ -93,6 +85,22 @@ class Monitoring():
         else:                                         self.snd_geo = SndlhcGeo.GeoInterface(options.geoFile[3:])
         self.MuFilter = self.snd_geo.modules['MuFilter']
         self.Scifi       = self.snd_geo.modules['Scifi']
+
+# MuFilter mapping of planes and bars 
+        self.systemAndPlanes   = {1:self.MuFilter.GetConfParI("MuFilter/NVetoPlanes"),
+                     2:self.MuFilter.GetConfParI("MuFilter/NUpstreamPlanes"),
+                     3:2*self.MuFilter.GetConfParI("MuFilter/NDownstreamPlanes")-1} # to arrive at 7 DS planes
+        self.systemAndBars     = {1:self.MuFilter.GetConfParI("MuFilter/NVetoBars"),
+                     2:self.MuFilter.GetConfParI("MuFilter/NUpstreamBars"),
+                     3:self.MuFilter.GetConfParI("MuFilter/NDownstreamBars")}
+        self.systemAndChannels = {1:[self.MuFilter.GetConfParI("MuFilter/VetonSiPMs"),0],
+                     2:[self.MuFilter.GetConfParI("MuFilter/UpstreamnSiPMs")-2,2],
+                     3:[self.MuFilter.GetConfParI("MuFilter/DownstreamnSiPMs"),0]}
+        self.sdict                     = {0:'Scifi',1:'Veto',2:'US',3:'DS'}
+
+        self.freq      =  160.316E6
+        self.TDC2ns = 1E9/self.freq
+
         self.zPos = self.getAverageZpositions()
 
         self.h = {}   # histogram storage

--- a/shipLHC/scripts/Survey-MufiScifi.py
+++ b/shipLHC/scripts/Survey-MufiScifi.py
@@ -143,7 +143,7 @@ latex = ROOT.TLatex()
 # MuFilter mapping of planes and bars 
 systemAndPlanes   = {1:MuFilter.GetConfParI("MuFilter/NVetoPlanes"),
                      2:MuFilter.GetConfParI("MuFilter/NUpstreamPlanes"),
-                     3:MuFilter.GetConfParI("MuFilter/NDownstreamPlanes")}
+                     3:2*MuFilter.GetConfParI("MuFilter/NDownstreamPlanes")-1} # to arrive at 7 DS planes
 systemAndBars     = {1:MuFilter.GetConfParI("MuFilter/NVetoBars"),
                      2:MuFilter.GetConfParI("MuFilter/NUpstreamBars"),
                      3:MuFilter.GetConfParI("MuFilter/NDownstreamBars")}

--- a/sndFairTasks/ConvRawData.cxx
+++ b/sndFairTasks/ConvRawData.cxx
@@ -856,6 +856,7 @@ void ConvRawData::DetMapping(string Path)
       offMap[Form("Veto_%iLeft",i)]  = {10000 + (i-1)*1000+ 0, 8, 2};//first channel, nSiPMs, nSides
       offMap[Form("Veto_%iRight",i)] = {10000 + (i-1)*1000+ 0, 8, 2};
     }
+    if (i==3) offMap[Form("Veto_%iVert",i)] = {10000 + (i-1)*1000+ 0, 8, 1};// 3rd Veto plane
     if (i<4)
     {
       // DS

--- a/sndFairTasks/boardMappingParser.cxx
+++ b/sndFairTasks/boardMappingParser.cxx
@@ -118,13 +118,16 @@ tuple<map<string, map<string, map<string, int>> >, map<string, map<string, map<s
         if (boardMapsMu["MuFilter"].find(bString.c_str()) == boardMapsMu["MuFilter"].end())
         {
           boardMapsMu["MuFilter"][bString] = {};
-        }          
+        }
         // Loop over the slots (the first is always left, the second always right)
         for (int i = 0; i < info.slots.size(); i++)
         {
           bString = Form("board_%i", info.board);
-          if (i==0) boardMapsMu["MuFilter"][bString][info.slots.at(i)] = Form("Veto_%dLeft", stoi(subel.key()));
-          else if (i==1) boardMapsMu["MuFilter"][bString][info.slots.at(i)] = Form("Veto_%dRight", stoi(subel.key()));
+          if (stoi(subel.key())<3){
+            if (i==0) boardMapsMu["MuFilter"][bString][info.slots.at(i)] = Form("Veto_%iLeft", stoi(subel.key()));
+            else if (i==1) boardMapsMu["MuFilter"][bString][info.slots.at(i)] = Form("Veto_%iRight", stoi(subel.key()));
+          }
+          if (stoi(subel.key())==3) boardMapsMu["MuFilter"][bString][info.slots.at(i)] = Form("Veto_%iVert", stoi(subel.key()));
         }
       }
       else if (el.key() =="us")


### PR DESCRIPTION
- adding Veto3 - detector, support for digitization, raw-data conversion, monitoring, 2dED
- having the Veto pit in the geometry of the TI18
- all backward compatible, including for the testbeam setup

- [x] tested running simulation -> digitization -> 2dED -> monitoring
- [x] tested running raw-data conversion & the  2dED
- [ ]  need more events for a data test on the monitoring  and that would go on a different PR for related changes

The 2024 det. configuration is already on eos: ` /eos/experiment/sndlhc/convertedData/physics/2024/geofile_sndlhc_TI18_V0_2024.root` so that people can run the 2dED when we start the automatic data conversion next week.