### PR TITLE
Updates start2024 data taking

### DIFF
--- a/python/shipunit.py
+++ b/python/shipunit.py
@@ -319,5 +319,5 @@ universe_mean_density = 1.e-25*g/cm3
 speedOfLight = 299792458*m/s
 # specific SNDLHC constants
 snd_freq   = 160.316*megahertz # sndlhc clock
-snd_TDC2ns = (1E9/freq)*ns
+snd_TDC2ns = (1E9/snd_freq)*ns
 

--- a/shipLHC/rawData/reverseMapping.py
+++ b/shipLHC/rawData/reverseMapping.py
@@ -38,6 +38,7 @@ class reversChannelMapping:
       for s in range(1,3):
         for o in ['Left','Right']: 
            self.offMap['Veto_'+str(s)+o] =[10000 + (s-1)*1000+ 0,8,2]    # first channel, nSiPMs, nSides, from bottom to top
+      self.offMap['Veto_3Vert'] = [10000+2*1000+0,8,1] # third vertical Veto plane
       for s in range(1,6):
           for o in ['Left','Right']: 
             self.offMap['US_'+str(s)+o] =[20000 + (s-1)*1000+ 9,-8,2]     # from top to bottom
@@ -81,7 +82,8 @@ class reversChannelMapping:
       bar_number   = fDetectorID%1000
       nSiPMs = aHit.GetnSiPMs()
       nSides = aHit.GetnSides()
-      if subsystem==3 and bar_number>59: side="Vert"
+      if (subsystem==3 and bar_number>59) or (subsystem==1 and plane==2):
+        side="Vert"
       elif channel <  nSiPMs: side = 'Left'
       else: side = 'Right'
       tag = self.sdict[subsystem]+'_'+str(plane+1)+side

--- a/shipLHC/rawData/runProd.py
+++ b/shipLHC/rawData/runProd.py
@@ -131,7 +131,7 @@ class prodManager():
                print('run not complete',r)
                continue  # not all files converted.
            print('executing DQ for run %i'%(r))
-           geoFile =  "../geofile_sndlhc_TI18_V1_2023.root"
+           geoFile =  "../geofile_sndlhc_TI18_V0_2024.root"
            os.system(monitorCommand.replace('XXXX',str(r)).replace('GGGG',geoFile)+" &")
            while self.count_python_processes('run_Monitoring')>(ncpus-2) or psutil.virtual_memory()[2]>90 : time.sleep(1800)
 
@@ -149,7 +149,8 @@ class prodManager():
            elif r  < 4855:   geoFile =  "../geofile_sndlhc_TI18_V5_14August2022.root"
            elif r  < 5172:  geoFile =  "../geofile_sndlhc_TI18_V6_08October2022.root"
            elif r  < 5485: geoFile =  "../geofile_sndlhc_TI18_V7_22November2022.root"
-           else: geoFile =  "../geofile_sndlhc_TI18_V1_2023.root"
+           elif r  < 7357: geoFile =  "../geofile_sndlhc_TI18_V1_2023.root"
+           else: geoFile =  "../geofile_sndlhc_TI18_V0_2024.root"
            os.system(monitorCommand.replace('XXXX',str(r)).replace('GGGG',geoFile)+" &")
            time.sleep(20)
            while self.count_python_processes('run_Monitoring')>(ncpus-5) or psutil.virtual_memory()[2]>90 : time.sleep(300)
@@ -391,8 +392,8 @@ if __name__ == '__main__':
        if options.server.find('eospublic')<0:
           path = "/mnt/raid1/data_online/" 
        else:
-          path = "/eos/experiment/sndlhc/raw_data/physics/2023_tmp/"
-          pathConv = "/eos/experiment/sndlhc/convertedData/physics/2023/"
+          path = "/eos/experiment/sndlhc/raw_data/physics/2024/ecc_run_06/"
+          pathConv = "/eos/experiment/sndlhc/convertedData/physics/2024/ecc_run_06/"
        
     elif options.prod == "reproc2022":
        path = "/eos/experiment/sndlhc/raw_data/physics/2022/"

--- a/shipLHC/scripts/run_Monitoring.py
+++ b/shipLHC/scripts/run_Monitoring.py
@@ -82,6 +82,7 @@ if not options.geoFile:
    if options.path.find('TI18')<0:
      if options.path.find('2022')>0 : options.geoFile =  "geofile_sndlhc_TI18_V0_2022.root"
      if options.path.find('2023')>0 : options.geoFile =  "geofile_sndlhc_TI18_V1_2023.root"
+     if options.path.find('2024')>0 : options.geoFile =  "geofile_sndlhc_TI18_V0_2024.root"
    else:
      if options.runNumber < 4575:
            options.geoFile =  "geofile_sndlhc_TI18_V3_08August2022.root"
@@ -136,7 +137,10 @@ else:
    if options.rawDataPath: rawDataPath = options.rawDataPath
 # works only for runs on EOS
    elif not options.server.find('eos')<0:
-      if options.path.find('2023')>0:
+      if options.path.find('2024')>0:
+          em_run = options.path[len(options.path) - 3:]
+          rawDataPath = "/eos/experiment/sndlhc/raw_data/physics/2024/ecc_run_"+em_run
+      elif options.path.find('2023')>0:
           rawDataPath = "/eos/experiment/sndlhc/raw_data/physics/2023/"
       elif options.path.find('2022')>0:
           rawDataPath = "/eos/experiment/sndlhc/raw_data/physics/2022/"

--- a/shipLHC/scripts/run_Monitoring.py
+++ b/shipLHC/scripts/run_Monitoring.py
@@ -137,7 +137,7 @@ else:
 # works only for runs on EOS
    elif not options.server.find('eos')<0:
       if options.path.find('2023')>0:
-          rawDataPath = "/eos/experiment/sndlhc/raw_data/physics/2023_tmp/"
+          rawDataPath = "/eos/experiment/sndlhc/raw_data/physics/2023/"
       elif options.path.find('2022')>0:
           rawDataPath = "/eos/experiment/sndlhc/raw_data/physics/2022/"
       else:

--- a/shipdata/ShipUnit.h
+++ b/shipdata/ShipUnit.h
@@ -324,7 +324,12 @@ namespace ShipUnit
     //
     static const Double_t universe_mean_density = 1.e-25*g/cm3;
     
+    // speed of light in vacuum
+    static const Double_t speedOfLight = 299792458*m/s;
     
+    // specific SNDLHC constants
+    static const Double_t snd_freq = 160.316*megahertz; // sndlhc clock
+    static const Double_t snd_TDC2ns = (1E9/snd_freq)*ns;
     };
     
 #endif /* defined(____ShipUnit__) */


### PR DESCRIPTION
At the start of the emulsion run, the necessity of a few updates emerged - raw data paths etc.
Then, there is the reverse board mapping that we use in the DAQ monitoring and which was missing the Veto3 support - I missed it in #210  since I only tested on MC and so with no DAQ monitoring.
Also I had to fix the shipunit bug introduced when renaming snd specific parameters...