### PR TITLE
Veto and US time alignment

### DIFF
--- a/shipLHC/MuFilter.cxx
+++ b/shipLHC/MuFilter.cxx
@@ -575,14 +575,20 @@ void MuFilter::GetLocalPosition(Int_t fDetectorID, TVector3& vLeft, TVector3& vR
   vRight.SetXYZ(locB[0],locB[1],locB[2]);
 }
 
-Float_t MuFilter::GetCorrectedTime(Int_t fDetectorID, Int_t channel, Double_t rawTime, Double_t L){
+// Calculate the time walk correction
+Float_t MuFilter::GetTimeWalk(Int_t fDetectorID, Int_t channel, Float_t qdc, TString tag){
+   std::vector<float> vec = conf_vectors["MuFilter/TW_DSa_"+std::to_string(fDetectorID)
+                                                           +"_"+std::to_string(channel)+tag];
+   /* A = vec[0]; B = vec[1]; C = vec[2];
+      D = vec[3]; E = vec[4]; F = vec[5]; */
+   Float_t Q = qdc-vec[0];
+   return vec[3]*Q/(vec[1]+vec[2]*pow(Q,2)) + vec[4]*Q + vec[5];
+}
+
+Float_t MuFilter::GetCorrectedTime(Int_t fDetectorID, Int_t channel, Double_t rawTime, Double_t L, Float_t qdc){
 /* expect time in u.ns  and  path length to sipm u.cm */
-/* calibration implemented only for DS! */
-/* channel 0 left or top, channel 1 right */
-	if (fDetectorID<30000){
-		LOG(ERROR) << "MuFilter::GetCorrectedTime: not yet implemented for Veto and DS, no correction applied" ;
-		return rawTime;
-	}
+/* returns the time in u.ns  */
+/* for DS: channel 0 left or top, channel 1 right */
 	TString tag = "";
 	if (eventHeader){
 		Int_t fRunNumber = eventHeader->GetRunId();
@@ -614,6 +620,12 @@ Float_t MuFilter::GetCorrectedTime(Int_t fDetectorID, Int_t channel, Double_t ra
 		  last_time_alignment_tag = tag;
 		}
 	}
+	if (fDetectorID<30000){
+	   return rawTime + GetTimeWalk(fDetectorID, channel, qdc, last_time_alignment_tag)
+	                  + conf_vectors["MuFilter/TW_DSa_"
+	                                 +std::to_string(fDetectorID)+"_"+std::to_string(channel)
+	                                 +last_time_alignment_tag].back();
+	}	
 	Float_t cor = rawTime;
 	int l = (fDetectorID-30000)/1000;
 	int ichannel60 = fDetectorID%1000;

--- a/shipLHC/MuFilter.h
+++ b/shipLHC/MuFilter.h
@@ -35,7 +35,8 @@ class MuFilter : public FairDetector
     /** Getposition **/
                  void GetPosition(Int_t id, TVector3& vLeft, TVector3& vRight); // or top and bottom
                  void GetLocalPosition(Int_t id, TVector3& vLeft, TVector3& vRight);
-                 Float_t GetCorrectedTime(Int_t id, Int_t c, Double_t t, Double_t L);
+                 Float_t GetTimeWalk(Int_t id, Int_t c, Float_t qdc, TString tag);
+                 Float_t GetCorrectedTime(Int_t id, Int_t c, Double_t t, Double_t L=0, Float_t QDC=-1.);
                  Int_t GetnSiPMs(Int_t detID);
                  Int_t GetnSides(Int_t detID);
 
@@ -43,9 +44,11 @@ class MuFilter : public FairDetector
 		void SetConfPar(TString name, Float_t value){conf_floats[name]=value;}
 		void SetConfPar(TString name, Int_t value){conf_ints[name]=value;}
 		void SetConfPar(TString name, TString value){conf_strings[name]=value;}
+		void SetConfPar(TString name, std::vector<float> values){conf_vectors[name]=values;}
 		Float_t  GetConfParF(TString name){return conf_floats[name];} 
 		Int_t       GetConfParI(TString name){return conf_ints[name];}
 		TString  GetConfParS(TString name){return conf_strings[name];}
+		std::vector<Float_t> GetConfParVector(TString name){return conf_vectors[name];}
 
 		/**      Initialization of the detector is done here    */
 		virtual void Initialize();
@@ -101,6 +104,7 @@ class MuFilter : public FairDetector
 		std::map<TString,Float_t> conf_floats;
 		std::map<TString,Int_t> conf_ints;
 		std::map<TString,TString> conf_strings;
+		std::map<TString,std::vector<Float_t>> conf_vectors;
 		SNDLHCEventHeader *eventHeader;
 
                 // Vector to store runs covered in the geometry file.

--- a/shipLHC/MuFilterHit.cxx
+++ b/shipLHC/MuFilterHit.cxx
@@ -9,7 +9,6 @@
 #include <TRandom.h>
 #include <iomanip> 
 
-Double_t speedOfLight = TMath::C() *100./1000000000.0 ; // from m/sec to cm/ns
 // -----   Default constructor   -------------------------------------------
 MuFilterHit::MuFilterHit()
   : SndlhcHit()

--- a/shipLHC/MuFilterHit.h
+++ b/shipLHC/MuFilterHit.h
@@ -29,10 +29,12 @@ class MuFilterHit : public SndlhcHit
     Float_t SumOfSignals(char* opt,Bool_t mask=kTRUE);
     std::map<TString,Float_t> SumOfSignals(Bool_t mask=kTRUE);
     std::map<Int_t,Float_t> GetAllSignals(Bool_t mask=kTRUE,Bool_t positive=kTRUE);
-    std::map<Int_t,Float_t> GetAllTimes(Bool_t mask=kTRUE);
-    Float_t  GetDeltaT(Bool_t mask=kTRUE);
-    Float_t  GetFastDeltaT(Bool_t mask=kTRUE);
-    Float_t  GetImpactT(Bool_t mask=kTRUE);
+    std::map<Int_t,Float_t> GetAllTimes(Bool_t mask=kTRUE, 
+                                        Bool_t apply_t_corr=kFALSE, 
+                                        Double_t SipmDistance=0.);
+    Float_t  GetDeltaT(Bool_t mask=kTRUE, Bool_t apply_t_corr=kFALSE, Double_t SipmDistance=0.);
+    Float_t  GetFastDeltaT(Bool_t mask=kTRUE, Bool_t apply_t_corr=kFALSE, Double_t SipmDistance=0.);
+    Float_t  GetImpactT(Bool_t mask=kTRUE, Bool_t apply_t_corr=kFALSE, Double_t SipmDistance=0.);
     bool isValid() const {return flag;}
     bool isMasked(Int_t i) const {return fMasked[i];}
     void SetMasked(Int_t i) {fMasked[i]=kTRUE;}
@@ -44,11 +46,18 @@ class MuFilterHit : public SndlhcHit
     /** Copy constructor **/
     MuFilterHit(const MuFilterHit& hit);
     MuFilterHit operator=(const MuFilterHit& hit);
+    /** Function to set the fTimesHelper array **/
+    void OptForTimeCorrections(Bool_t mask, Bool_t apply, Double_t SipmDistance);
 
     Float_t flag;   ///< flag
     Float_t fMasked[16];  /// masked signal
+    /* Helper container for time-corrected or raw times 
+       depending if time alignment is requested.
+       The unit is clock cycles same as for the SndlhcHit's
+       times[16] data member */
+    Float_t fTimesHelper[16];
 
-    ClassDef(MuFilterHit,5);
+    ClassDef(MuFilterHit,6);
     
 
 };


### PR DESCRIPTION
Here we can discuss the implementation of the US and the Veto time alignment.

For this first implementation, when one needs the time calibration for a single channel, they have to use the detector method `GetCorrectedTime` as before.
However, for multi-channel readout (Veto, US, DS horizontal),  if an operation is to be performed using all SiPM timings per hit, `apply_t_correction flag` and `distance to SiPM` parameters are added to all timing getters in the MuFilterHit class. This way the user can call one function per hit that could perform the time calibration for all channels before returning the time value - impact time, delta L/R time.
It is not optimal that there are now 2 ways to return the calibration time - through the detector ( per signle channel at a time!) and through the hit (for multi-channel hits).