### PR TITLE
Divide the MuFi digi signal on the number of readout sides.

### DIFF
--- a/shipLHC/MuFilterHit.cxx
+++ b/shipLHC/MuFilterHit.cxx
@@ -89,8 +89,9 @@ MuFilterHit::MuFilterHit(Int_t detID, std::vector<MuFilterPoint*> V)
         MuFilterDet->GetPosition(fDetectorID,vLeft, vRight);
         Double_t distance_Left    =  (vLeft-impact).Mag();
         Double_t distance_Right =  (vRight-impact).Mag();
-        signalLeft+=signal*TMath::Exp(-distance_Left/attLength);
-        signalRight+=signal*TMath::Exp(-distance_Right/attLength);
+        // Simple model: divide signal between nSides
+        signalLeft+=signal/nSides*TMath::Exp(-distance_Left/attLength);
+        signalRight+=signal/nSides*TMath::Exp(-distance_Right/attLength);
 
       // for the timing, find earliest particle and smear with time resolution
         Double_t ptime    = (*p)->GetTime();


### PR DESCRIPTION
This is the simplest way to distribute the deposited energy. In the future we aim to provide a more sophisticated model taking into account light reflection and its effect on the number of photons seen by a SiPM. This effect could be significant when the particles pass close to the readout edge.