### PR TITLE
Fixed Veto3 bar id numbering for the conversion tasks

### DIFF
--- a/shipLHC/rawData/ConvRawData.py
+++ b/shipLHC/rawData/ConvRawData.py
@@ -252,7 +252,7 @@ class ConvRawDataPY(ROOT.FairTask):
        for s in range(1,3):
            for o in ['Left','Right']: 
               self.offMap['Veto_'+str(s)+o] =[10000 + (s-1)*1000+ 0,8,2]    # first channel, nSiPMs, nSides, from bottom to top
-       self.offMap['Veto_3Vert'] = [10000 + 2*1000+ 0,8,1]
+       self.offMap['Veto_3Vert'] = [10000 + 2*1000+ 6,-8,1]
        for s in range(1,6):
            for o in ['Left','Right']: 
               self.offMap['US_'+str(s)+o] =[20000 + (s-1)*1000+ 9,-8,2]     # from top to bottom

--- a/sndFairTasks/ConvRawData.cxx
+++ b/sndFairTasks/ConvRawData.cxx
@@ -856,7 +856,7 @@ void ConvRawData::DetMapping(string Path)
       offMap[Form("Veto_%iLeft",i)]  = {10000 + (i-1)*1000+ 0, 8, 2};//first channel, nSiPMs, nSides
       offMap[Form("Veto_%iRight",i)] = {10000 + (i-1)*1000+ 0, 8, 2};
     }
-    if (i==3) offMap[Form("Veto_%iVert",i)] = {10000 + (i-1)*1000+ 0, 8, 1};// 3rd Veto plane
+    if (i==3) offMap[Form("Veto_%iVert",i)] = {10000 + (i-1)*1000+ 6, -8, 1};// 3rd Veto plane
     if (i<4)
     {
       // DS


### PR DESCRIPTION
It was going right to left instead of the correct left to right(wrt beam 1 direction). The data having this swapped detIDs are already reprocessed.


Let me place a bit of supporting material:
![supporting_material_Veto3_map](https://github.com/SND-LHC/sndsw/assets/84918585/0dec0ad6-e744-433c-ac7b-a06fc115d0e0)
