### PR TITLE
Fix MuFilterHit constructors

### DIFF
--- a/shipLHC/MuFilterHit.h
+++ b/shipLHC/MuFilterHit.h
@@ -13,9 +13,11 @@ class MuFilterHit : public SndlhcHit
 
     /** Default constructor **/
     MuFilterHit();
-    MuFilterHit(Int_t detID);
+    explicit MuFilterHit(Int_t detID);
     /** Constructor with detector id, number of SiPMs per side, number of sides **/
     MuFilterHit(Int_t detID,Int_t nP,Int_t nS);
+    MuFilterHit(const MuFilterHit& hit) = default;
+    MuFilterHit& operator=(const MuFilterHit& hit) = default;
 
     // Constructor from MuFilterPoint
     MuFilterHit(Int_t detID,std::vector<MuFilterPoint*>);
@@ -41,14 +43,11 @@ class MuFilterHit : public SndlhcHit
     bool isVertical();
     bool isShort(Int_t);
   private:
-    /** Copy constructor **/
-    MuFilterHit(const MuFilterHit& hit);
-    MuFilterHit operator=(const MuFilterHit& hit);
 
     Float_t flag;   ///< flag
     Float_t fMasked[16];  /// masked signal
 
-    ClassDef(MuFilterHit,5);
+    ClassDef(MuFilterHit, 6);
     
 
 };


### PR DESCRIPTION
Add copy constructor, assignment operator (both default) and make single-argument constructor explicit to avoid accidental conversion