### PR TITLE
Restructure monitoring

### DIFF
--- a/shipLHC/rawData/runProd.py
+++ b/shipLHC/rawData/runProd.py
@@ -81,7 +81,7 @@ class prodManager():
          for p in partitions[r]:
              self.runSinglePartition(path,runNr,str(p).zfill(4),EOScopy=True,check=True)
 
-   def getRunNrFromOffline(self,rMin=-1,rMax=9999):
+   def getRunNrFromOffline(self,rMin=-1,rMax=99999):
       self.dqDataFiles = []
       hList = str( subprocess.check_output("xrdfs "+os.environ['EOSSHIP']+" ls /eos/experiment/sndlhc/www/offline",shell=True) )
       for x in hList.split('\\n'):
@@ -134,7 +134,7 @@ class prodManager():
            os.system(monitorCommand.replace('XXXX',str(r)).replace('GGGG',options.geofile)+" &")
            while self.count_python_processes('run_Monitoring')>(ncpus-2) or psutil.virtual_memory()[2]>90 : time.sleep(1800)
 
-   def RerunDataQuality(self,runNrs=[],rMin=-1,rMax=9999):
+   def RerunDataQuality(self,runNrs=[],rMin=-1,rMax=99999):
       monitorCommand = "python $SNDSW_ROOT/shipLHC/scripts/run_Monitoring.py -r XXXX --server=$EOSSHIP \
                         -b 100000 -p "+pathConv+" -g GGGG "\
                         +" --postScale "+str(options.postScale)+ " --ScifiResUnbiased 1 --batch --sudo "
@@ -247,7 +247,7 @@ class prodManager():
            if rc==0: success[r].append(x)
      return success
 
-   def getFileList(self,p,latest,rmax=99999,minSize=10E6):
+   def getFileList(self,p,latest,rmax=999999,minSize=10E6):
       inventory = {}
       dirList = str( subprocess.check_output("xrdfs "+self.options.server+" ls "+p,shell=True) )
       for x in dirList.split('\\n'):
@@ -305,7 +305,7 @@ class prodManager():
                 eventChain.Add(options.server+pathConv+'run_'+str(r).zfill(6)+'/'+p)
            return eventChain.GetEntries()
 
-   def checkEOS(self,copy=False,latest=4361,rlast=99999):
+   def checkEOS(self,copy=False,latest=4361,rlast=999999):
        self.eosInventory = self.getFileList(path,latest,rlast)
        tmp = self.options.server 
        self.options.server = "root://snd-server-1.cern.ch/"
@@ -377,7 +377,7 @@ if __name__ == '__main__':
     parser.add_argument("--postScale", dest="postScale",help="post scale events, 1..10..100", default=-1,type=int)
     parser.add_argument("--parallel", dest="parallel",default=1,type=int)
     parser.add_argument("-rMin", dest="rMin",help="first run to process", default=-1,type=int)
-    parser.add_argument("-rMax", dest="rMax",help="last run to process", default=9999,type=int)
+    parser.add_argument("-rMax", dest="rMax",help="last run to process", default=99999,type=int)
     parser.add_argument("-p", dest="path", help="path to raw data",required=False,default="")
     parser.add_argument("-d", dest="pathConv", help="path to converted data",required=False,default="")
     parser.add_argument("--saveTo", dest="saveTo", help="output storage path", default="")

--- a/shipLHC/scripts/Scifi_monitoring.py
+++ b/shipLHC/scripts/Scifi_monitoring.py
@@ -197,6 +197,7 @@ class Scifi_residuals(ROOT.FairTask):
        ut.bookHist(h,detector+'trackChi2/ndof','track chi2/ndof vs ndof; #chi^{2}/Ndof; Ndof',100,0,100,20,0,20)
 # type of crossing, check for b1only,b2nob1,nobeam
        self.xing = {'':True,'B1only':False,'B2noB1':False,'noBeam':False}
+       '''
        for xi in self.xing:
           if not self.M.fsdict and not self.M.hasBunchInfo and xi!='': continue
           ut.bookHist(h,detector+'trackSlopes'+xi,'track slope; x/z [mrad]; y/z [mrad]',1000,-100,100,1000,-100,100)
@@ -206,7 +207,7 @@ class Scifi_residuals(ROOT.FairTask):
           for item in h:
             if isinstance(h[item], ROOT.TH2) and (item.find('trackPos')>0 or item.find('trackSlopes')>0): 
               h[item].SetTitleOffset(1.1, 'Y')
-
+       '''
        if alignPar:
             for x in alignPar:
                self.M.Scifi.SetConfPar(x,alignPar[x])
@@ -285,11 +286,12 @@ class Scifi_residuals(ROOT.FairTask):
                  slopeX = mom.X()/mom.Z()
                  slopeY = mom.Y()/mom.Z()
                  rc = h[detector+'trackChi2/ndof'].Fill(fitStatus.getChi2()/(fitStatus.getNdf()+1E-10),fitStatus.getNdf())
+                 '''
                  self.M.fillHist2(detector+'trackSlopes',slopeX*1000-pos.X()/48.2,slopeY*1000-pos.Y()/48.2)
                  self.M.fillHist2(detector+'trackSlopesXL',slopeX-pos.X()/48200,slopeY-pos.Y()/48200)
                  self.M.fillHist2(detector+'trackPos',pos.X(),pos.Y())
                  if abs(slopeX)<0.1 and abs(slopeY)<0.1:  self.M.fillHist2(detector+'trackPosBeam',pos.X(),pos.Y())
-
+                 '''
 
        if not theTrack: return
 
@@ -464,6 +466,7 @@ class Scifi_residuals(ROOT.FairTask):
        for proj in P: T.append('scifiRes'+proj)
        for canvas in T:
            self.M.myPrint(self.M.h[canvas],"Scifi-"+canvas,subdir='scifi/expert')
+       '''
        for xi in self.xing:
            if not self.M.fsdict and not self.M.hasBunchInfo and xi!='': continue
            tname = detector+'trackDir'+xi
@@ -498,6 +501,7 @@ class Scifi_residuals(ROOT.FairTask):
            rc = h[detector+'trackPos'+xi].Draw('colz')
            if x=='': self.M.myPrint(self.M.h[tname],detector+'trackPos'+xi,subdir='scifi/shifter')
            else:     self.M.myPrint(self.M.h[tname],detector+'trackPos'+xi,subdir='scifi/shifter/'+xi)
+       '''
            
 class Scifi_trackEfficiency(ROOT.FairTask):
    " track efficiency tag with DS track"

--- a/shipLHC/scripts/run_Monitoring.py
+++ b/shipLHC/scripts/run_Monitoring.py
@@ -191,7 +191,7 @@ monitorTasks['Scifi_hitMaps']   = Scifi_monitoring.Scifi_hitMaps()
 monitorTasks['Mufi_hitMaps']   = Mufi_monitoring.Mufi_hitMaps()
 monitorTasks['Mufi_QDCcorellations']   = Mufi_monitoring.Mufi_largeVSsmall()
 if options.postScale<2: monitorTasks['Veto_Efficiency']   = Mufi_monitoring.Veto_Efficiency()
-monitorTasks['Scifi_residuals'] = Scifi_monitoring.Scifi_residuals()   # time consuming
+#monitorTasks['Scifi_residuals'] = Scifi_monitoring.Scifi_residuals()   # time consuming
 if options.interactive:  monitorTasks['EventDisplay']   = EventDisplay_Task.twod()
 
 for m in monitorTasks:


### PR DESCRIPTION
Since 2024 data flow is huge, needed to remove the Scifi_residuals module from the offline monitoring. 
This module is used to check the target alignment, but this year the latter is ready weeks after the offline monitoring is run!
So it is pointless to keep it.
In any case, after each alignment, the offline monitoring WITH Scifi_residuals module is run as a x-check.

We also went above runN 10 000, so needed a tiny update of the allowed run numbers when reading EOS dir contents.