### PR TITLE
Sort the alignment tags in increasing run number

### DIFF
--- a/shipLHC/MuFilter.cxx
+++ b/shipLHC/MuFilter.cxx
@@ -468,6 +468,7 @@ void MuFilter::InitEvent(SNDLHCEventHeader *e){
 	covered_runs_time_alignment.push_back(stoi(tag_string.substr(tag_string.find("t_")+2)));
       }
     }
+    std::sort(covered_runs_time_alignment.begin(),covered_runs_time_alignment.end());
   }
 };
 

--- a/shipLHC/Scifi.cxx
+++ b/shipLHC/Scifi.cxx
@@ -439,6 +439,7 @@ void Scifi::InitEvent(SNDLHCEventHeader *e){
 	covered_runs_time_alignment.push_back(stoi(tag_string.substr(tag_string.find("t_")+2)));
       }
     }
+    std::sort(covered_runs_time_alignment.begin(),covered_runs_time_alignment.end());
     // Position alignment tags
     for (auto key : conf_floats){
       tag_string = key.first.Data();
@@ -446,6 +447,7 @@ void Scifi::InitEvent(SNDLHCEventHeader *e){
 	covered_runs_position_alignment.push_back(stoi(tag_string.substr(tag_string.find("t_")+2)));
       }
     }
+    std::sort(covered_runs_position_alignment.begin(),covered_runs_position_alignment.end());
   }
 };
 


### PR DESCRIPTION
When run numbers became larger than 10k the order of their respective tags in the helper alignment vector stopped being consecutive as numbers starting with 1 came in first. This breaks the internal logic how tags are selected wrt run number and sorting was added to resume the order.

ps. merging straight up as this is a simple bug fix