### PR TITLE
Revert commit b7c521656 to bring the special vetoPoint back

### DIFF
--- a/sndFairTasks/DigiTaskSND.cxx
+++ b/sndFairTasks/DigiTaskSND.cxx
@@ -64,6 +64,7 @@ InitStatus DigiTaskSND::Init()
     }
     // Get input MC points
     fScifiPointArray = static_cast<TClonesArray*>(ioman->GetObject("ScifiPoint"));
+    fvetoPointArray = static_cast<TClonesArray*>(ioman->GetObject("vetoPoint"));
     fEmulsionPointArray = static_cast<TClonesArray*>(ioman->GetObject("EmulsionDetPoint"));
     fMuFilterPointArray = static_cast<TClonesArray*>(ioman->GetObject("MuFilterPoint"));
     if (!fScifiPointArray and !fMuFilterPointArray) {
@@ -73,6 +74,7 @@ InitStatus DigiTaskSND::Init()
     // copy branches from input file:
     fMCTrackArray = static_cast<TClonesArray*>(ioman->GetObject("MCTrack"));
     ioman->Register("MCTrack", "ShipMCTrack", fMCTrackArray, kTRUE);
+    ioman->Register("vetoPoint", "vetoPoints", fvetoPointArray, kTRUE);
     ioman->Register("EmulsionDetPoint", "EmulsionDetPoints", fEmulsionPointArray, fCopyEmulsionPoints);
     ioman->Register("ScifiPoint", "ScifiPoints", fScifiPointArray, kTRUE);
     ioman->Register("MuFilterPoint", "MuFilterPoints", fMuFilterPointArray, kTRUE);

--- a/sndFairTasks/DigiTaskSND.h
+++ b/sndFairTasks/DigiTaskSND.h
@@ -54,6 +54,7 @@ class DigiTaskSND : public FairTask
     TClonesArray* fScifiDigiHitArray;
     TClonesArray* fMuFilterHit2MCPointsArray; // link to MC truth
     TClonesArray* fScifiHit2MCPointsArray;
+    TClonesArray* fvetoPointArray;
     TClonesArray* fEmulsionPointArray;
     TClonesArray* fMCTrackArray;
 
@@ -64,7 +65,7 @@ class DigiTaskSND : public FairTask
     DigiTaskSND(const DigiTaskSND&);
     DigiTaskSND& operator=(const DigiTaskSND&);
 
-    ClassDef(DigiTaskSND, 5);
+    ClassDef(DigiTaskSND, 6);
 };
 
 #endif /* DIGITASKSND_H_ */


### PR DESCRIPTION
These points are actually used in the Floor class that describes the tunnel and the upstream rock and are a handle to study interactions in those insensitive volumes.
For example, vetoPoint objects are used in a special case of muonDIS simulations to study the energy loss in the upstream rock. It is important to always have a branch for them, even if empty most of the time, as one can use different MC samples together: one with no MC point information about interactions in the rock and one where this is included.


It is basically undoing something I asked @olantwin to do a few weeks ago when we were looking at emulsion MC point storage..