### PR TITLE
Units update and fix

### DIFF
--- a/python/shipunit.py
+++ b/python/shipunit.py
@@ -319,5 +319,5 @@ universe_mean_density = 1.e-25*g/cm3
 speedOfLight = 299792458*m/s
 # specific SNDLHC constants
 snd_freq   = 160.316*megahertz # sndlhc clock
-snd_TDC2ns = (1E9/snd_freq)*ns
+snd_TDC2ns = 1./snd_freq
 

--- a/shipdata/ShipUnit.h
+++ b/shipdata/ShipUnit.h
@@ -106,7 +106,7 @@ namespace ShipUnit
     //
     // Energy [E]
     //
-    static const Double_t megaelectronvolt = 1. ;
+    static const Double_t megaelectronvolt = 1./1000.; // used identical value to shipunit.py
     static const Double_t     electronvolt = 1.e-6*megaelectronvolt;
     static const Double_t kiloelectronvolt = 1.e-3*megaelectronvolt;
     static const Double_t gigaelectronvolt = 1.e+3*megaelectronvolt;

--- a/shipdata/ShipUnit.h
+++ b/shipdata/ShipUnit.h
@@ -329,7 +329,7 @@ namespace ShipUnit
     
     // specific SNDLHC constants
     static const Double_t snd_freq = 160.316*megahertz; // sndlhc clock
-    static const Double_t snd_TDC2ns = (1E9/snd_freq)*ns;
+    static const Double_t snd_TDC2ns = 1./snd_freq;
     };
     
 #endif /* defined(____ShipUnit__) */


### PR DESCRIPTION
Two units' updates and fixes:

1.  correct the snd_TDC2ns param
2.  update the c++ unit's file ShipUnit.h to use GeV base energy unit
This is the case for shipunit.py already.

The duplication of unit's file, see issue #213, is not fixed in this PR.