### PR TITLE
Fix linking for Plane classes

### DIFF
--- a/analysis/tools/AnalysisToolsLinkDef.h
+++ b/analysis/tools/AnalysisToolsLinkDef.h
@@ -34,9 +34,9 @@
 #pragma link C++ function snd::analysis_tools::showerInteractionWall(const TClonesArray &, int, std::string);
 #pragma link C++ function snd::analysis_tools::GetDataBasePath(const std::string &, int);
 #pragma link C++ function snd::analysis_tools::GetTChain(const std::string &, int, int);
-#pragma link C++ function snd::analysis_tools::GetTChain(std::string);
+#pragma link C++ function snd::analysis_tools::GetTChain(const std::string &);
 #pragma link C++ function snd::analysis_tools::GetGeoPath(const std::string &,int);
-#pragma link C++ function snd::analysis_tools::GetGeometry(std::string);
+#pragma link C++ function snd::analysis_tools::GetGeometry(const std::string &);
 #pragma link C++ function snd::analysis_tools::FillScifi(const snd::Configuration &, TClonesArray *, Scifi *);
 #pragma link C++ function snd::analysis_tools::FillUS(const snd::Configuration &, TClonesArray *, MuFilter *);
 

--- a/analysis/tools/sndGeometryGetter.cxx
+++ b/analysis/tools/sndGeometryGetter.cxx
@@ -42,7 +42,7 @@ std::string snd::analysis_tools::GetGeoPath(const std::string& csv_file_path, in
 }
 
 // Get SciFi and MuFilter geometries
-std::pair<Scifi *, MuFilter *> snd::analysis_tools::GetGeometry(std::string geometry_path)
+std::pair<Scifi *, MuFilter *> snd::analysis_tools::GetGeometry(const std::string& geometry_path)
 {
     TPython::Exec("import SndlhcGeo");
     TPython::Exec(("SndlhcGeo.GeoInterface('" + geometry_path + "')").c_str());

--- a/analysis/tools/sndGeometryGetter.h
+++ b/analysis/tools/sndGeometryGetter.h
@@ -10,7 +10,7 @@
 namespace snd {
     namespace analysis_tools {
         std::string GetGeoPath(const std::string& csv_file_path, int run_number);
-        std::pair<Scifi *, MuFilter *> GetGeometry(std::string geometry_path);
+        std::pair<Scifi *, MuFilter *> GetGeometry(const std::string& geometry_path);
         std::pair<Scifi *, MuFilter *> GetGeometry(const std::string& csv_file_path, int run_number);
     }
 }

--- a/analysis/tools/sndTchainGetter.cxx
+++ b/analysis/tools/sndTchainGetter.cxx
@@ -52,7 +52,7 @@ std::unique_ptr<TChain> snd::analysis_tools::GetTChain(const std::string& csv_fi
     return tchain;
 };
 
-std::unique_ptr<TChain> snd::analysis_tools::GetTChain(std::string file_name){
+std::unique_ptr<TChain> snd::analysis_tools::GetTChain(const std::string& file_name){
     auto tchain = std::make_unique<TChain>("rawConv");
     tchain->Add(file_name.c_str());
     return tchain;

--- a/analysis/tools/sndTchainGetter.h
+++ b/analysis/tools/sndTchainGetter.h
@@ -9,7 +9,7 @@
 namespace snd {
     namespace analysis_tools {
         std::unique_ptr<TChain> GetTChain(const std::string& csv_file_path, int run_number, int n_files = -1);  
-        std::unique_ptr<TChain> GetTChain(std::string file_name);
+        std::unique_ptr<TChain> GetTChain(const std::string& file_name);
         std::string GetDataBasePath(const std::string& csv_file_path, int run_number); 
     }
 }


### PR DESCRIPTION
Plane classes were not correctly added to ROOT dictionary.

Functions are still not added to ROOT dictionary (even the scifitools already present). I tried listing the header files in the CMakeLists.txt file but it did not solve the issue.