### PR TITLE
Adds python script to make run lists with DB info

### DIFF
--- a/analysis/makeRunListDB.py
+++ b/analysis/makeRunListDB.py
@@ -1,0 +1,150 @@
+import pymongo
+import argparse
+import xml.etree.ElementTree as ET
+from datetime import datetime
+from collections import defaultdict
+import os
+
+parser = argparse.ArgumentParser(
+    prog="makeRunListDB",
+    description="Extracts a list of runs from the SND@LHC DB, matching the conditions given in the arguments. Produces an XML file with the run list and a summary of the selection.")
+parser.add_argument("--name", type=str, help="Run list name", required=True)
+parser.add_argument("--years", nargs="+", type=int, help="Years to be included, e.g. 2022 2023", required=True)
+parser.add_argument("--min_events", type=int, help="Minimum number of events in run", default=0)
+parser.add_argument("--min_lumi", type=float, help="Minimum integrated luminosity for a run to be included, in fb-1", default=0.)
+parser.add_argument("--min_stable_time", type=float, help="Minimum stable beams time of the corresponding LHC fill for a run to be included, in minutes", default=0.)
+parser.add_argument("--particle_B1", type=str, help="Beam 1 particle, e.g. p+ or PB82", required=True)
+parser.add_argument("--particle_B2", type=str, help="Beam 2 particle, e.g. p+ or PB82", required=True)
+parser.add_argument("--min_energy", type=float, help="Minimum beam energy (in GeV)", default=0.)
+parser.add_argument("--max_energy", type=float, help="Maximum beam energy (in GeV)", default=0.)
+parser.add_argument("--min_bunches_IP1", type=int, help="Minimum number of bunches colliding at IP1", default=0)
+parser.add_argument("--max_bunches_IP1", type=int, help="Maximum number of bunches colliding at IP1", default=0)
+parser.add_argument("--include_runs", nargs="+", type=int, help="Runs to include, regardless of the other criteria", default=[])
+parser.add_argument("--exclude_runs", nargs="+", type=int, help="Runs to exclude from the list", default=[])
+args = parser.parse_args()
+
+client = pymongo.MongoClient("sndrundb.cern.ch")
+db = client.sndrundb
+
+pipeline = []
+
+# Get the run list corresponding to the selected years
+pipeline.append({"$match": {"$expr": {"$in": [{"$year": "$start"}, args.years]}}})
+
+# Select runs with a minimum of min_events events:
+if args.min_events > 0:
+    pipeline.append({"$match": {"events": {"$gt": args.min_events}}})
+
+# Combine data fill from the LPC
+pipeline.append({"$lookup": {"from": "FILL_LPC", "localField": "fill", "foreignField": "_id", "as": "LPC"}})
+
+if args.min_lumi > 0.:
+    # Select runs with at least min_lumi integrated luminosity
+    pipeline.append({"$match": {"LPC.ATLAS_Int_Lumi": {"$gt": args.min_lumi*1e6}}})
+
+if args.min_stable_time > 0.:
+    # Select runs with at least min_stable_time minutes of stable beams
+    pipeline.append({"$match": {"LPC.Stable_time": {"$gt": args.min_stable_time/60.}}})
+
+# Select B1 particle
+pipeline.append({"$match": {"LPC.Particle_B1": args.particle_B1}})
+
+# Select B2 particle
+pipeline.append({"$match": {"LPC.Particle_B2": args.particle_B2}})
+
+if args.min_energy > 0:
+    # Select runs with args.min_energy energy
+    pipeline.append({"$match": {"LPC.Energy": {"$gt": args.min_energy}}})
+
+if args.max_energy > 0:
+    # Select runs with args.max_energy energy
+    pipeline.append({"$match": {"LPC.Energy": {"$lt": args.max_energy}}})
+    
+if args.min_bunches_IP1 > 0:
+    # Select runs with at least min_bunches_IP1 bunches colliding at IP1
+    pipeline.append({"$match": {"LPC.Coll_IP_1_5": {"$gt": args.min_bunches_IP1}}})
+    
+if args.max_bunches_IP1 > 0:
+    # Select runs with at most max_bunches_IP1 bunches colliding at IP1
+    pipeline.append({"$match": {"LPC.Coll_IP_1_5": {"$lt": args.max_bunches_IP1}}})
+
+if len(args.exclude_runs) > 0:
+    pipeline.append({"$match": {"runNumber": {"$nin" : args.exclude_runs}}})
+
+# Expression for Calculating run length from start and stop datetimes
+run_length_expr = {"$dateDiff": {"startDate": "$start", "endDate": "$stop", "unit": "minute"}}
+
+# Extract the following data from the DB
+projection = {"$project":{"_id": 0, # Do not extract DB entry ID 
+                          "run_number": "$runNumber", # Run number
+                          "n_events": "$events", # Number of events
+                          "start": 1, # Start date
+                          "end": 1, # End date
+                          "duration": run_length_expr, # Run duration
+                          "n_files": {"$size": "$files"}, # Number of files
+                          "path": {"$first": "$files.file"}, # Path of the first file
+                          "fill_number": "$fill", # Fill number
+                          "fill_int_lumi": {"$first": "$LPC.ATLAS_Int_Lumi"}, # Integrated luminosity
+                          "fill_stable_time" : {"$first": "$LPC.Stable_time"}} # Stable beams duration
+              }
+
+pipeline.append(projection)
+
+result = list(db["EcsData"].aggregate(pipeline))
+
+if len(args.include_runs) > 0:
+    include_pipeline = []
+    include_pipeline.append({"$match": {"runNumber": {"$in": args.include_runs}}})
+    include_pipeline.append(projection)
+
+    include_result = list(db["EcsData"].aggregate(include_pipeline))
+
+    result.extend(list(include_result))
+
+result.sort(key=lambda x: x["run_number"])
+
+# Get the time now
+now = datetime.now()
+
+# Format into xml tree
+root = ET.Element("runlist")
+
+meta_data = ET.SubElement(root, "meta")
+ET.SubElement(meta_data, "name").text = args.name
+ET.SubElement(meta_data, "datetime").text = now.strftime("%Y-%m-%dT%H:%M:%S.%f")
+selection = ET.SubElement(meta_data, "selection")
+ET.SubElement(selection, "years").text = ','.join([str(y) for y in args.years])
+for criterion in ["min_events", "min_lumi", "min_stable_time", "particle_B1", "particle_B2", "min_energy", "max_energy", "min_bunches_IP1", "max_bunches_IP1", "exclude_runs", "include_runs"]:
+    ET.SubElement(selection, criterion).text = str(getattr(args, criterion))
+runs = ET.SubElement(root, "runs")
+
+# Counters for summary statistics
+n_runs = 0
+totals = defaultdict(int)
+
+# Run loop
+for run in result:
+    this_run = ET.SubElement(runs, "run")
+    totals["n_runs"] += 1
+    for field_name in ["run_number", "start", "end", "n_events", "duration", "n_files", "fill_number", "fill_int_lumi", "fill_stable_time", "path"]:
+        try:
+            data = run[field_name]
+        except KeyError:
+            continue
+
+        if field_name == "path":
+            data = os.path.dirname(data)
+        
+        ET.SubElement(this_run, field_name).text = str(data)    
+
+        if field_name not in ["run_number", "start", "end", "fill_number", "path", "fill_int_lumi", "fill_stable_time"] and data is not None:
+            totals["tot_"+field_name] += data
+
+stats = ET.SubElement(meta_data, "statistics")
+for key, data in totals.items():
+    ET.SubElement(stats, key).text = str(data)
+    
+# Write to xml file
+tree = ET.ElementTree(root)
+ET.indent(tree, space="    ")
+tree.write(args.name+"_"+str(now.timestamp())+".xml", encoding="utf-8", xml_declaration=True)


### PR DESCRIPTION
A simple python script that produces a list of runs matching a set of criteria supplied as arguments. The script interfaces with the SND@LHC database to extract run and LHC parameters. The output is an XML file that contains useful information for processing these runs, such as the file location.
```
[cvilela@lxplus9105 analysis]$ python makeRunListDB.py --help
usage: makeRunListDB [-h] --name NAME --years YEARS [YEARS ...] [--min_events MIN_EVENTS] [--min_lumi MIN_LUMI] [--min_stable_time MIN_STABLE_TIME] --particle_B1 PARTICLE_B1 --particle_B2 PARTICLE_B2
                     [--min_energy MIN_ENERGY] [--max_energy MAX_ENERGY] [--min_bunches_IP1 MIN_BUNCHES_IP1] [--max_bunches_IP1 MAX_BUNCHES_IP1] [--include_runs INCLUDE_RUNS [INCLUDE_RUNS ...]]
                     [--exclude_runs EXCLUDE_RUNS [EXCLUDE_RUNS ...]]

Extracts a list of runs from the SND@LHC DB, matching the conditions given in the arguments. Produces an XML file with the run list and a summary of the selection.

optional arguments:
  -h, --help            show this help message and exit
  --name NAME           Run list name
  --years YEARS [YEARS ...]
                        Years to be included, e.g. 2022 2023
  --min_events MIN_EVENTS
                        Minimum number of events in run
  --min_lumi MIN_LUMI   Minimum integrated luminosity for a run to be included, in fb-1
  --min_stable_time MIN_STABLE_TIME
                        Minimum stable beams time of the corresponding LHC fill for a run to be included, in minutes
  --particle_B1 PARTICLE_B1
                        Beam 1 particle, e.g. p+ or PB82
  --particle_B2 PARTICLE_B2
                        Beam 2 particle, e.g. p+ or PB82
  --min_energy MIN_ENERGY
                        Minimum beam energy (in GeV)
  --max_energy MAX_ENERGY
                        Maximum beam energy (in GeV)
  --min_bunches_IP1 MIN_BUNCHES_IP1
                        Minimum number of bunches colliding at IP1
  --max_bunches_IP1 MAX_BUNCHES_IP1
                        Maximum number of bunches colliding at IP1
  --include_runs INCLUDE_RUNS [INCLUDE_RUNS ...]
                        Runs to include, regardless of the other criteria
  --exclude_runs EXCLUDE_RUNS [EXCLUDE_RUNS ...]
                        Runs to exclude from the list
```
For example, to produce a sensible list of runs for 2022 and 2023 electronic detector analyses:
`python3  makeRunListDB.py --name numu_22_23_v2 --years 2022 2023 --min_events 100000 --min_lumi 0.001 --min_stable_time 10 --particle_B1 p+ --particle_B2 p+ --min_energy 6400 --min_bunches_IP1 100 --exclude_runs 5025 5026 5027 5028 5030 5031 --include_runs 6268 6279`
The command above produces a runlist named `numu_22_23_v2`, including data from 2022 and 2023, from runs with at least 100000 events, corresponding to fills with at least 0.001 fb-1, at least 10 minutes of stable beam time, protons on both beams, at least 6400 GeV beam energy, and a minimum of 100 bunches colliding at IP1. Runs 5025 to 5031 are excluded (because the data files don't look right) and runs 6268 and 6279 are included by hand as they look OK, but are probably not correctly registered in the DB.

A timestamp is added to the output file name to facilitate reproducibility, metadata including the date of runlist creation and the run selection criteria is included in the XML file, as well as a few summary statistics.

The first few lines of the resulting file look like this:
```
[cvilela@lxplus9105 analysis]$ cat numu_22_23_v2_1762801091.542757.xml 
<?xml version='1.0' encoding='utf-8'?>
<runlist>
    <meta>
        <name>numu_22_23_v2</name>
        <datetime>2025-11-10T19:58:11.542757</datetime>
        <selection>
            <years>2022,2023</years>
            <min_events>100000</min_events>
            <min_lumi>0.001</min_lumi>
            <min_stable_time>10.0</min_stable_time>
            <particle_B1>p+</particle_B1>
            <particle_B2>p+</particle_B2>
            <min_energy>6400.0</min_energy>
            <max_energy>0.0</max_energy>
            <min_bunches_IP1>100</min_bunches_IP1>
            <max_bunches_IP1>0</max_bunches_IP1>
            <exclude_runs>[5025, 5026, 5027, 5028, 5030, 5031]</exclude_runs>
            <include_runs>[6268, 6279]</include_runs>
        </selection>
        <statistics>
            <n_runs>273</n_runs>
            <tot_n_events>17051760463</tot_n_events>
            <tot_duration>131211</tot_duration>
            <tot_n_files>17200</tot_n_files>
        </statistics>
    </meta>
    <runs>
        <run>
            <run_number>4449</run_number>
            <start>2022-07-14 15:40:15</start>
            <end>2022-07-15 04:10:29</end>
            <n_events>12367098</n_events>
            <duration>749</duration>
            <n_files>13</n_files>
            <fill_number>7978</fill_number>
            <fill_int_lumi>49950.61328125</fill_int_lumi>
            <fill_stable_time>11.213055555555556</fill_stable_time>
            <path>/eos/experiment/sndlhc/raw_data/physics/2022/run_004449</path>
        </run>
        <run>
            <run_number>4488</run_number>
            <start>2022-07-18 00:42:16</start>
            <end>2022-07-18 07:26:44</end>
            <n_events>5026155</n_events>
            <duration>404</duration>
            <n_files>6</n_files>
            <fill_number>8007</fill_number>
            <fill_int_lumi>19001.380859375</fill_int_lumi>
            <fill_stable_time>4.142777777777778</fill_stable_time>
            <path>/eos/experiment/sndlhc/raw_data/physics/2022/run_004488</path>
        </run>
```
