### PR TITLE
Make MCEventBuilder arguments required

### DIFF
--- a/shipLHC/run_MCEventBuilder.py
+++ b/shipLHC/run_MCEventBuilder.py
@@ -8,9 +8,9 @@ import shipunit as u
 
 # ------------ Argument parser ----------------
 parser = ArgumentParser()
-parser.add_argument("-f", "--inputFile", help="Input file")
-parser.add_argument("-g", "--geoFile", help="geo file")
-parser.add_argument("-o", "--outputFile", help="Output file")
+parser.add_argument("-f", "--inputFile", help="Input file", required=True)
+parser.add_argument("-g", "--geoFile", help="geo file", required=True)
+parser.add_argument("-o", "--outputFile", help="Output file", required=True)
 parser.add_argument("-i", "--firstEvent", type=int, default=0, help="First event to process")
 parser.add_argument("-n", "--nEvents", type=int, default=0, help="Number of events to process (0 = all)")
 parser.add_argument("--saveFirst25nsOnly", action="store_true", help="Only store the first 25-ns chunk of each event")


### PR DESCRIPTION
This way a helpful message is printed out when the required arguments are not given.