### PR TITLE
Change pythia8 decayer configuration method

### DIFF
--- a/shipLHC/run_simSND.py
+++ b/shipLHC/run_simSND.py
@@ -197,6 +197,7 @@ if simEngine == "PG":
         f'({options.EVx},{options.EVy},{options.EVz})[cm × cm × cm] \n'
         f'with a uniform x-y spread of (Dx,Dy)=({options.Dx},{options.Dy})[cm × cm]'
         f' and {options.nZSlices} z slices in steps of {options.zSliceStep}[cm].')
+  run.SetPythiaDecayer('DecayConfigPy8.C')
   ROOT.FairLogger.GetLogger().SetLogScreenLevel("WARNING") # otherwise stupid printout for each event
 # -----muon DIS Background------------------------
 if simEngine == "muonDIS":
@@ -209,6 +210,7 @@ if simEngine == "muonDIS":
    primGen.AddGenerator(DISgen)
    options.nEvents = min(options.nEvents,DISgen.GetNevents())
    inactivateMuonProcesses = True # avoid unwanted hadronic events of "incoming" muon flying backward
+   run.SetPythiaDecayer('DecayConfigPy8.C')
    print('MuDIS position info input=',mu_start, mu_end)
    print('Generate ',options.nEvents,' with DIS input', ' first event',options.firstEvent)
 
@@ -257,6 +259,7 @@ if simEngine == "Ntuple":
    Ntuplegen.Init(inputFile,options.firstEvent)
    primGen.AddGenerator(Ntuplegen)
    options.nEvents = min(options.nEvents,Ntuplegen.GetNevents())
+   run.SetPythiaDecayer('DecayConfigPy8.C')
 
 if simEngine == "MuonBack":
 # reading muon tracks from FLUKA


### PR DESCRIPTION
Previous Pythia8 decayer configuration file had no effect and the hadrons were still decayed by Geant4. For charm (and beauty) hadrons this meant only the most likely hadronic decay mode was implemented (e.g., D+ always decayed to K pi pi).

The version in this PR uses the geant4 command interface to select the particles that are decayed with Pythia8.

All charm and beauty hadrons are set to decay with Pythia as well as etas and taus. As in the previous implementation, the decays of short lived hadrons are still done by Geant4, as setting them to Pythia makes the program crash.

In addition, the Pythia8 decayer is now turned on by default for particle gun, muon DIS, and Ntuple events.