### PR TITLE
Geant4 but better

### DIFF
--- a/gconfig/SetCuts.C
+++ b/gconfig/SetCuts.C
@@ -1,6 +1,8 @@
 
 /** Configuration macro for setting common cuts and processes for G3, G4 and Fluka (M. Al-Turany 27.03.2008)
     specific cuts and processes to g3 or g4 should be set in the g3Config.C, g4Config.C or flConfig.C
+    Comment out all cuts defined in this macro (S. Ilieva 3.03.2026)
+    essentially removing the 1 MeV particle production cut-off for SND@LHC G4 simulations
 
 */
 
@@ -33,20 +35,22 @@ void SetCuts()
   gMC->SetProcess("LOSS",1); /**energy loss*/
   gMC->SetProcess("MULS",1); /**multiple scattering*/
 
-  Double_t cut1 = 1.0E-3;         // GeV --> 1 MeV
-  Double_t cutb = 1.0E4;          // GeV --> 10 TeV
-  Double_t tofmax = 1.E10;        // seconds
-  cout << "SetCuts Macro: Setting cuts.." <<endl;
+  cout << "SetCuts Macro: No cuts to be set in here." <<endl;
+  
+  //Double_t cut1 = 1.0E-3;         // GeV --> 1 MeV
+  //Double_t cutb = 1.0E4;          // GeV --> 10 TeV
+  //Double_t tofmax = 1.E10;        // seconds
+  //cout << "SetCuts Macro: Setting cuts.." <<endl;
 
-  gMC->SetCut("CUTGAM",cut1);   /** gammas (GeV)*/
-  gMC->SetCut("CUTELE",cut1);   /** electrons (GeV)*/
-  gMC->SetCut("CUTNEU",cut1);   /** neutral hadrons (GeV)*/
-  gMC->SetCut("CUTHAD",cut1);   /** charged hadrons (GeV)*/
-  gMC->SetCut("CUTMUO",cut1);   /** muons (GeV)*/
-  gMC->SetCut("BCUTE",cut1);    /** electron bremsstrahlung (GeV)*/
-  gMC->SetCut("BCUTM",cut1);    /** muon and hadron bremsstrahlung(GeV)*/
-  gMC->SetCut("DCUTE",cut1);    /** delta-rays by electrons (GeV)*/
-  gMC->SetCut("DCUTM",cut1);    /** delta-rays by muons (GeV)*/
-  gMC->SetCut("PPCUTM",cut1);   /** direct pair production by muons (GeV)*/
-  gMC->SetCut("TOFMAX",tofmax); /**time of flight cut in seconds*/
+  //gMC->SetCut("CUTGAM",cut1);   /** gammas (GeV)*/
+  //gMC->SetCut("CUTELE",cut1);   /** electrons (GeV)*/
+  //gMC->SetCut("CUTNEU",cut1);   /** neutral hadrons (GeV)*/
+  //gMC->SetCut("CUTHAD",cut1);   /** charged hadrons (GeV)*/
+  //gMC->SetCut("CUTMUO",cut1);   /** muons (GeV)*/
+  //gMC->SetCut("BCUTE",cut1);    /** electron bremsstrahlung (GeV)*/
+  //gMC->SetCut("BCUTM",cut1);    /** muon and hadron bremsstrahlung(GeV)*/
+  //gMC->SetCut("DCUTE",cut1);    /** delta-rays by electrons (GeV)*/
+  //gMC->SetCut("DCUTM",cut1);    /** delta-rays by muons (GeV)*/
+  //gMC->SetCut("PPCUTM",cut1);   /** direct pair production by muons (GeV)*/
+  //gMC->SetCut("TOFMAX",tofmax); /**time of flight cut in seconds*/
 }

--- a/gconfig/g4Config.C
+++ b/gconfig/g4Config.C
@@ -25,7 +25,7 @@ void Config()
 /// When more than one options are selected, they should be separated with '+'
 /// character: eg. stepLimit+specialCuts.
    TG4RunConfiguration* runConfiguration 
-           = new TG4RunConfiguration("geomRoot", "QGSP_BERT_HP_PEN", "stepLimiter+specialCuts+specialControls");
+           = new TG4RunConfiguration("geomRoot", "FTFP_BERT_HP_EMZ", "stepLimiter+specialCuts+specialControls");
 
 /// Create the G4 VMC 
    TGeant4* geant4 = new TGeant4("TGeant4", "The Geant4 Monte Carlo", runConfiguration);

--- a/gconfig/g4config.in
+++ b/gconfig/g4config.in
@@ -5,6 +5,13 @@
 /mcVerbose/all 0
 /mcTracking/loopVerbose 0    # suggested by Ivana Hrivnacova to switch off *** Particle reached max step number ....
 
+# Geant4 range cut for all geo regions and all supported particle types: e+,e-, gamma, proton
+/mcPhysics/rangeCuts 2 mm
+# range cut for all geo regions and selected particle e.g.
+#/mcPhysics/rangeCutForGamma 2 mm
+# print the Geant4 and VMC cuts per material
+#/mcRegions/print true
+
 # switch on other sources of di muon 
 /physics_lists/em/PositronToMuons true
 /physics_lists/em/GammaToMuons true

--- a/geometry/sndLHC_H4geom_config.py
+++ b/geometry/sndLHC_H4geom_config.py
@@ -259,16 +259,17 @@ with ConfigRegistry.register_config("basic") as c:
         c.MuFilter.DS4ShiftX =    1.39 * u.cm
         
        #digitization parameters
-        c.MuFilter.DsAttenuationLength   =  350 * u.cm                #  values between 300 cm and 400cm observed for H6 testbeam
-        c.MuFilter.DsTAttenuationLength =  700 * u.cm                # top readout with mirror on bottom
-        c.MuFilter.VandUpAttenuationLength = 999 * u.cm        # no significante attenuation observed for H6 testbeam
-        c.MuFilter.VandUpSiPMcalibrationL    = 25.*1000.       # 1.65 MeV = 41 qcd 
-        c.MuFilter.VandUpSiPMcalibrationS    = 25.*1000.
+        c.MuFilter.DsAttenuationLength  =  230*u.cm          # values between 130cm and 330cm are observed for TI18 in years 2022-2025, but between 300 cm and 400cm for H6 testbeam
+        c.MuFilter.DsTAttenuationLength =  700*u.cm          # top readout with mirror on bottom, TI18 and H6 observables agree
+        c.MuFilter.VandUpAttenuationLength = 210*u.cm        # while no significant attenuation observed for H6 testbeam
+        c.MuFilter.VTAttenuationLength =  999*u.cm           # Veto 3, no significant attenuation observed in 2024-2025 data
+        c.MuFilter.VandUpSiPMcalibrationL    = 50.*1000.       # 1.65 MeV = 41 qcd over 6 Large SiPMs(one side)
+        c.MuFilter.VandUpSiPMcalibrationS    = 0.              # no MIP signal for small SiPMs, delayed and compromised response in general
         c.MuFilter.DsSiPMcalibration             = 25.*1000.
         c.MuFilter.timeResol = 150.*u.picosecond
-        c.MuFilter.VandUpPropSpeed    = 12.5*u.cm/u.nanosecond
-        c.MuFilter.DsPropSpeed        = 14.3*u.cm/u.nanosecond
-
+        c.MuFilter.VandUpPropSpeed    = 13.6*u.cm/u.nanosecond
+        c.MuFilter.DsPropSpeed        = 15.1*u.cm/u.nanosecond
+        
         c.Floor = AttrDict(z=48000.*u.cm) # to place tunnel in SND_@LHC coordinate system
         c.Floor.DX = 1.0*u.cm 
         c.Floor.DY = -4.5*u.cm #  subtract 4.5cm to avoid overlaps 

--- a/geometry/sndLHC_H6geom_config.py
+++ b/geometry/sndLHC_H6geom_config.py
@@ -245,15 +245,16 @@ with ConfigRegistry.register_config("basic") as c:
         c.MuFilter.VETOBoxY2        = c.MuFilter.VETOLocY + c.MuFilter.VetoBarZ/2 + c.MuFilter.SupportBoxD
 
        #digitization parameters
-        c.MuFilter.DsAttenuationLength   =  350 * u.cm                #  values between 300 cm and 400cm observed for H6 testbeam
-        c.MuFilter.DsTAttenuationLength =  700 * u.cm                # top readout with mirror on bottom
-        c.MuFilter.VandUpAttenuationLength = 999 * u.cm        # no significante attenuation observed for H6 testbeam
-        c.MuFilter.VandUpSiPMcalibrationL    = 25.*1000.       # 1.65 MeV = 41 qcd 
-        c.MuFilter.VandUpSiPMcalibrationS    = 25.*1000.
+        c.MuFilter.DsAttenuationLength  =  230*u.cm          # values between 130cm and 330cm are observed for TI18 in years 2022-2025, but between 300 cm and 400cm for H6 testbeam
+        c.MuFilter.DsTAttenuationLength =  700*u.cm          # top readout with mirror on bottom, TI18 and H6 observables agree
+        c.MuFilter.VandUpAttenuationLength = 210*u.cm        # while no significant attenuation observed for H6 testbeam
+        c.MuFilter.VTAttenuationLength =  999*u.cm           # Veto 3, no significant attenuation observed in 2024-2025 data
+        c.MuFilter.VandUpSiPMcalibrationL    = 50.*1000.       # 1.65 MeV = 41 qcd over 6 Large SiPMs(one side)
+        c.MuFilter.VandUpSiPMcalibrationS    = 0.              # no MIP signal for small SiPMs, delayed and compromised response in general
         c.MuFilter.DsSiPMcalibration             = 25.*1000.
         c.MuFilter.timeResol = 150.*u.picosecond
-        c.MuFilter.VandUpPropSpeed    = 12.5*u.cm/u.nanosecond
-        c.MuFilter.DsPropSpeed        = 14.3*u.cm/u.nanosecond
+        c.MuFilter.VandUpPropSpeed    = 13.6*u.cm/u.nanosecond
+        c.MuFilter.DsPropSpeed        = 15.1*u.cm/u.nanosecond
 
         c.Floor = AttrDict(z=48000.*u.cm) # to place tunnel in SND_@LHC coordinate system
         c.Floor.DX = 1.0*u.cm 

--- a/geometry/sndLHC_HXgeom_config.py
+++ b/geometry/sndLHC_HXgeom_config.py
@@ -256,15 +256,16 @@ with ConfigRegistry.register_config("basic") as c:
         c.MuFilter.DS4ShiftX =    1.39 * u.cm
         
        #digitization parameters
-        c.MuFilter.DsAttenuationLength   =  350 * u.cm                #  values between 300 cm and 400cm observed for H6 testbeam
-        c.MuFilter.DsTAttenuationLength =  700 * u.cm                # top readout with mirror on bottom
-        c.MuFilter.VandUpAttenuationLength = 999 * u.cm        # no significante attenuation observed for H6 testbeam
-        c.MuFilter.VandUpSiPMcalibrationL    = 25.*1000.       # 1.65 MeV = 41 qcd 
-        c.MuFilter.VandUpSiPMcalibrationS    = 25.*1000.
+        c.MuFilter.DsAttenuationLength  =  230*u.cm          # values between 130cm and 330cm are observed for TI18 in years 2022-2025, but between 300 cm and 400cm for H6 testbeam
+        c.MuFilter.DsTAttenuationLength =  700*u.cm          # top readout with mirror on bottom, TI18 and H6 observables agree
+        c.MuFilter.VandUpAttenuationLength = 210*u.cm        # while no significant attenuation observed for H6 testbeam
+        c.MuFilter.VTAttenuationLength =  999*u.cm           # Veto 3, no significant attenuation observed in 2024-2025 data
+        c.MuFilter.VandUpSiPMcalibrationL    = 50.*1000.       # 1.65 MeV = 41 qcd over 6 Large SiPMs(one side)
+        c.MuFilter.VandUpSiPMcalibrationS    = 0.              # no MIP signal for small SiPMs, delayed and compromised response in general
         c.MuFilter.DsSiPMcalibration             = 25.*1000.
         c.MuFilter.timeResol = 150.*u.picosecond
-        c.MuFilter.VandUpPropSpeed    = 12.5*u.cm/u.nanosecond
-        c.MuFilter.DsPropSpeed        = 14.3*u.cm/u.nanosecond
+        c.MuFilter.VandUpPropSpeed    = 13.6*u.cm/u.nanosecond
+        c.MuFilter.DsPropSpeed        = 15.1*u.cm/u.nanosecond
 
         c.Floor = AttrDict(z=48000.*u.cm) # to place tunnel in SND_@LHC coordinate system
         c.Floor.DX = 1.0*u.cm 

--- a/geometry/sndLHC_TI18geom_config.py
+++ b/geometry/sndLHC_TI18geom_config.py
@@ -317,15 +317,16 @@ with ConfigRegistry.register_config("basic") as c:
         c.MuFilter.DS4ShiftX = 0.0
 
        #digitization parameters
-        c.MuFilter.DsAttenuationLength   =  350 * u.cm                #  values between 300 cm and 400cm observed for H6 testbeam
-        c.MuFilter.DsTAttenuationLength =  700 * u.cm                # top readout with mirror on bottom
-        c.MuFilter.VandUpAttenuationLength = 999 * u.cm        # no significante attenuation observed for H6 testbeam
+        c.MuFilter.DsAttenuationLength  =  230*u.cm          # values between 130cm and 330cm are observed for TI18 in years 2022-2025, but between 300 cm and 400cm for H6 testbeam
+        c.MuFilter.DsTAttenuationLength =  700*u.cm          # top readout with mirror on bottom, TI18 and H6 observables agree
+        c.MuFilter.VandUpAttenuationLength = 210*u.cm        # while no significant attenuation observed for H6 testbeam
+        c.MuFilter.VTAttenuationLength =  999*u.cm           # Veto 3, no significant attenuation observed in 2024-2025 data
         c.MuFilter.VandUpSiPMcalibrationL    = 50.*1000.       # 1.65 MeV = 41 qcd over 6 Large SiPMs(one side)
         c.MuFilter.VandUpSiPMcalibrationS    = 0.              # no MIP signal for small SiPMs, delayed and compromised response in general
         c.MuFilter.DsSiPMcalibration             = 25.*1000.
         c.MuFilter.timeResol = 150.*u.picosecond
-        c.MuFilter.VandUpPropSpeed    = 12.5*u.cm/u.nanosecond
-        c.MuFilter.DsPropSpeed        = 14.9*u.cm/u.nanosecond
+        c.MuFilter.VandUpPropSpeed    = 13.6*u.cm/u.nanosecond
+        c.MuFilter.DsPropSpeed        = 15.1*u.cm/u.nanosecond
 
         c.Floor = AttrDict(z=48000.*u.cm) # to place tunnel in SND_@LHC coordinate system
         c.Floor.DX = 1.0*u.cm 

--- a/shipLHC/MuFilterHit.cxx
+++ b/shipLHC/MuFilterHit.cxx
@@ -60,7 +60,7 @@ MuFilterHit::MuFilterHit(Int_t detID, std::vector<MuFilterPoint*> V)
      else { 
               if (floor(detID/10000)==1 && nSides==1){
                  // top readout with mirror on bottom
-                 attLength = 2*MuFilterDet->GetConfParF("MuFilter/VandUpAttenuationLength");
+                 attLength = 2*MuFilterDet->GetConfParF("MuFilter/VTAttenuationLength");
               }
               else {attLength = MuFilterDet->GetConfParF("MuFilter/VandUpAttenuationLength");}
               siPMcalibration = MuFilterDet->GetConfParF("MuFilter/VandUpSiPMcalibrationL");

--- a/shipLHC/run_digiSND.py
+++ b/shipLHC/run_digiSND.py
@@ -71,20 +71,48 @@ snd_geo = SndlhcGeo.GeoInterface(options.geoFile)
 lsOfGlobals  = ROOT.gROOT.GetListOfGlobals()
 scifiDet     = lsOfGlobals.FindObject('Scifi')
 mufiDet      = lsOfGlobals.FindObject('MuFilter')
-mufiDet.SetConfPar("MuFilter/DsAttenuationLength",350 * u.cm)		#  values between 300 cm and 400cm observed for H6 testbeam
-mufiDet.SetConfPar("MuFilter/DsTAttenuationLength",700 * u.cm)		# top readout with mirror on bottom
-mufiDet.SetConfPar("MuFilter/VandUpAttenuationLength",999 * u.cm)	# no significante attenuation observed for H6 testbeam
-mufiDet.SetConfPar("MuFilter/DsSiPMcalibrationS",25.*1000.)			# in MC: 1.65 keV are about 41.2 qdc
-mufiDet.SetConfPar("MuFilter/VandUpPropSpeed",12.5*u.cm/u.nanosecond);
-mufiDet.SetConfPar("MuFilter/DsPropSpeed",14.3*u.cm/u.nanosecond);
 scifiDet.SetConfPar("Scifi/nphe_min",options.ts)   # threshold
 scifiDet.SetConfPar("Scifi/nphe_max",options.ss) # saturation
-scifiDet.SetConfPar("Scifi/timeResol",150.*u.picosecond) # time resolution in ps
-scifiDet.SetConfPar("MuFilter/timeResol",150.*u.picosecond) # time resolution in ps, first guess
+
+####
+# The lines below aim to reproduce the original digitization case, but urge the user to regenerate
+# the sample shall it be outdated from before the removal of the 1MeV production cut, which
+# coincides with MuFi digi const update.
+#
 # in MC productions generated before July 2022 Scifi signal speed is missing from the geofile
+better_update = False
 if scifiDet.GetConfParF("Scifi/signalSpeed")==0:
   scifiDet.SetConfPar("Scifi/signalSpeed", 15*u.cm/u.nanosecond)
+  better_update = True
+# geofiles before March 2026 don't have the Veto 3 atten.length  
+if mufiDet.GetConfParF("MuFilter/VTAttenuationLength")==0:
+  mufiDet.SetConfPar("MuFilter/VTAttenuationLength",999*u.cm)
+  better_update = True
+# old digi constants from before the MuFi response update 
+if mufiDet.GetConfParF("MuFilter/VandUpAttenuationLength")==999*u.cm:
+  better_update = True
+# in very ancient MC productions it is possible some digitization params are missing
+# set them here values updated in March 2026.
+if mufiDet.GetConfParF("MuFilter/DsAttenuationLength")==0 or\
+     mufiDet.GetConfParF("MuFilter/VandUpPropSpeed")==0 :
+  mufiDet.SetConfPar("MuFilter/DsAttenuationLength",230*u.cm)
+  mufiDet.SetConfPar("MuFilter/DsTAttenuationLength",700*u.cm)
+  mufiDet.SetConfPar("MuFilter/VandUpAttenuationLength",210*u.cm)
+  mufiDet.SetConfPar("MuFilter/VTAttenuationLength",999*u.cm)
+  mufiDet.SetConfPar("MuFilter/DsSiPMcalibration",25.*1000.)
+  # 1.65 MeV = 41 qcd over 6 Large SiPMs(one side)
+  mufiDet.SetConfPar("MuFilter/VandUpSiPMcalibrationL",50.*1000.)
+  # no MIP signal for small SiPMs, delayed and compromised response in general
+  mufiDet.SetConfPar("MuFilter/VandUpSiPMcalibrationS",0.)
+  mufiDet.SetConfPar("MuFilter/VandUpPropSpeed",13.6*u.cm/u.nanosecond);
+  mufiDet.SetConfPar("MuFilter/DsPropSpeed",15.1*u.cm/u.nanosecond);
+  scifiDet.SetConfPar("Scifi/timeResol",150.*u.picosecond)
+  mufiDet.SetConfPar("MuFilter/timeResol",150.*u.picosecond) # time resolution in ps, first guess
+  better_update = True
 
+if better_update:
+  print("WARNING: Simulation file preceding the production cut change! Consider regenerating from scratch!")
+####
 
 # Fair digitization task
 if options.FairTask_digi:

--- a/shipLHC/run_simSND.py
+++ b/shipLHC/run_simSND.py
@@ -32,6 +32,7 @@ parser.add_argument("--PG",      dest="pg",      help="Use Particle Gun", requir
 parser.add_argument("--pID",     dest="pID",     help="id of particle used by the gun (default=22)", required=False, default=22, type=int)
 parser.add_argument("--Estart",  dest="Estart",  help="start of energy range of particle gun for muflux detector (default=10 GeV)", required=False, default=10, type=float)
 parser.add_argument("--Eend",    dest="Eend",    help="end of energy range of particle gun for muflux detector (default=10 GeV)", required=False, default=10, type=float)
+parser.add_argument('--eMin_store', type=float, help="kinetic energy cut for !particle storage! in MeV", dest='emin_store', default=100.)
 
 parser.add_argument("--PGrunID", dest="PGrunID",help="PG run ID", required=False, type=int)
 parser.add_argument("--multiplePGSources", help="Multiple particle guns in a x-y plane at a fixed z or in a 3D volume", action="store_true")
@@ -325,10 +326,10 @@ if MCTracksWithHitsOnly:
  fStack.SetEnergyCut(-100.*u.MeV)
 elif MCTracksWithEnergyCutOnly:
  fStack.SetMinPoints(-1)
- fStack.SetEnergyCut(100.*u.MeV)
+ fStack.SetEnergyCut(options.emin_store*u.MeV)
 elif MCTracksWithHitsOrEnergyCut: 
  fStack.SetMinPoints(1)
- fStack.SetEnergyCut(100.*u.MeV)
+ fStack.SetEnergyCut(options.emin_store*u.MeV)
 elif options.deepCopy: 
  fStack.SetMinPoints(0)
  fStack.SetEnergyCut(0.*u.MeV)

--- a/shipLHC/scripts/Survey-MufiScifi.py
+++ b/shipLHC/scripts/Survey-MufiScifi.py
@@ -2832,7 +2832,7 @@ def analyze_EfficiencyAndResiduals(readHists=False,mode='S',local=True,zoom=Fals
      hist.GetYaxis().SetRangeUser(ymin,ymax)
      hist.Draw('colz')
 # get time x correlation, X = m*dt + b
-     h['gdtLRvsX_'+key] = ROOT.TGraph()
+     h['gdtLRvsX_'+key] = ROOT.TGraphErrors()
      g = h['gdtLRvsX_'+key]
      xproj = hist.ProjectionX('tmpx')
      if xproj.GetSumOfWeights()==0:   continue
@@ -2844,9 +2844,14 @@ def analyze_EfficiencyAndResiduals(readHists=False,mode='S',local=True,zoom=Fals
             X   = hist.GetXaxis().GetBinCenter(nx)
             rc = tmp.Fit('gaus','NQS')
             res = rc.Get()
-            if not res: dt = tmp.GetMean()
-            else:   dt = res.Parameter(1)
+            if not res: 
+              dt = tmp.GetMean()
+              err = tmp.GetStd()
+            else:
+              dt = res.Parameter(1)
+              err =res.Parameter(2)
             g.SetPoint(np,X,dt)
+            g.SetPointError(np, 0, err)
             np+=1
      g.SetLineColor(ROOT.kRed)
      g.SetLineWidth(2)


### PR DESCRIPTION
Important changes:

- change physics list to FTFP_BERT_HP_EMZ
- remove the 1MeV cut-off from the simulation
- start using production cut range at 2mm
- revisit the signal speed and attenuation lengths for Veto/US/DS detectors, this time using 2022-2025 TI18 data (see [slides](https://indico.cern.ch/event/1660132/contributions/6976264/attachments/3236815/5771934/Software_news_11March_2026.pdf) and data from issue #296).

Minor updates
- add flag to set the kin E for *particle track storage* through command line, default is 100MeV
- in the digi step, warn users if the use old sim files


In terms of muon rate, using the 2025 sample of 2022LHC conf (100Mpp col), before we got 500Hz(5524 SciFi tracks) and now it is 510Hz(5541 SciFi tracks). I guess this slight increase of 1% is mainly due to physics list change.


Also, some stats on the resources needed for simulations using this G4 setup:
`PMU` : `2 s/event`
`H4 TB e@300GeV, W target`: `2 mins/event`


PMU jobs: 1k events per file, ~1214 files with averages:
Real Time: 2113.65 ± 17.52 s
CPU  Time: 2065.01 ± 16.83 s

jobs for H4 TB e@300GeV, W target: 10 events per file, ~1500 files with averages:
Real Time: 1225.29 ± 8.39 s
CPU  Time: 1194.67 ± 8.13 s
