### PR TITLE
Support for 2025 filling scheme extraction

### DIFF
--- a/shipLHC/rawData/ConvRawData.py
+++ b/shipLHC/rawData/ConvRawData.py
@@ -46,6 +46,7 @@ class ConvRawDataPY(ROOT.FairTask):
          if options.path.find('2022')!=-1: fpath = "/eos/experiment/sndlhc/convertedData/physics/2022/"
          elif options.path.find('2023')!=-1: fpath = "/eos/experiment/sndlhc/convertedData/physics/2023/"
          elif options.path.find('2024')!=-1: fpath = "/eos/experiment/sndlhc/convertedData/physics/2024/"
+         elif options.path.find('2025')!=-1: fpath = "/eos/experiment/sndlhc/convertedData/physics/2025/"
          else: fpath = "/eos/experiment/sndlhc/convertedData/commissioning/TI18/"
          fg = ROOT.TFile.Open(options.server+fpath+"/FSdict.root")
          pkl = Unpickler(fg)

--- a/shipLHC/rawData/ConvRawData.py
+++ b/shipLHC/rawData/ConvRawData.py
@@ -504,6 +504,8 @@ class ConvRawDataPY(ROOT.FairTask):
                   system = self.MufiSystem[board_id][tofpet_id]
                   key = (tofpet_id%2)*1000 + tofpet_channel
                   tmp = self.boardMaps['MuFilter'][board][self.slots[tofpet_id]]
+                  # mini DTs are labelled DS 5V, board is 32
+                  if (tmp == "DS_5Vert"): continue
                   if self.options.debug or not tmp.find('not')<0: print('debug',tmp,system,key,board,tofpet_id,tofpet_id%2,tofpet_channel)
                   sipmChannel = 99
                   if not key in self.TofpetMap[system]:
@@ -639,6 +641,8 @@ class ConvRawDataPY(ROOT.FairTask):
                   system = self.MufiSystem[board_id][tofpet_id]
                   key = (tofpet_id%2)*1000 + tofpet_channel
                   tmp = self.boardMaps['MuFilter'][board][self.slots[tofpet_id]]
+                  # mini DTs are labelled DS 5V, board is 32
+                  if (tmp == "DS_5Vert"): continue
                   if self.options.debug or not tmp.find('not')<0: print('debug',tmp,system,key,board,tofpet_id,tofpet_id%2,tofpet_channel)
                   sipmChannel = 99
                   if not key in self.TofpetMap[system]:

--- a/shipLHC/scripts/FillingScheme.py
+++ b/shipLHC/scripts/FillingScheme.py
@@ -117,6 +117,7 @@ class fillingScheme():
         Y = "2022"
         if fillnr > 8500 : Y = "2023"
         if fillnr >= 9323 : Y="2024"
+        if fillnr >= 10406 : Y="2025"
         if not self.lpcFillingscheme:
              with urlopen('https://lpc.web.cern.ch/cgi-bin/fillTable.py?year='+Y) as webpage:
                self.lpcFillingscheme = webpage.read().decode()
@@ -177,6 +178,7 @@ class fillingScheme():
      Y = "2022"
      if fillnr>8500: Y = "2023"
      if fillnr>=9323: Y="2024"
+     if fillnr>=10406 : Y="2025"
      if not fromnxcals and not fromAtlas:
        try:
           with urlopen('https://lpc.web.cern.ch/cgi-bin/fillAnalysis.py?year='+Y+'&action=fillData&exp=ATLAS&fillnr='+str(fillnr)) as webpage:
@@ -440,12 +442,12 @@ class fillingScheme():
         print('Name of filling scheme: ',fs_name_table)
         if fs_name_table==0: 
           return -1
-        # since 2024 new there is new storage of FS in json files, no csv
+        # since 2024 there is new storage of FS in json files, no csv
         fs_url="https://gitlab.cern.ch/lhc-injection-scheme/injection-schemes/-/raw/master/"+\
                  fs_name_table+".json"
         F = ROOT.TFile(self.path+'fillingScheme-'+fillNr+'.root','recreate')
         nt = ROOT.TNtuple('fill'+fillNr,'b1 IP1 IP2','B1:IP1:IP2:IsB2')
-        # Get the 2024 data
+        # Get the data for year>=2024
         # 9323 is first fillNr for 2024
         if int(fillNr) >= 9323: 
           # Get the JSON file content from the web
@@ -2062,6 +2064,12 @@ if __name__ == '__main__':
        em_run = options.rawData[options.rawData.find("run_"):]
        options.convpath = "/eos/experiment/sndlhc/convertedData/physics/2024/"+em_run
        options.rmin = 7649-1
+       offline =www+"offline.html"
+    elif options.rawData.find('2025')>0:
+       # extract the em target run from the rawData path
+       em_run = options.rawData[options.rawData.find("run_"):]
+       options.convpath = "/eos/experiment/sndlhc/convertedData/physics/2025/"+em_run
+       options.rmin = 10919-1 #10587 fillN
        offline =www+"offline.html"
     FS = fillingScheme()
     FS.Init(options)

--- a/sndFairTasks/ConvRawData.cxx
+++ b/sndFairTasks/ConvRawData.cxx
@@ -333,6 +333,8 @@ void ConvRawData::Process0()
            system = MufiSystem[board_id][tofpet_id];
            key = (tofpet_id%2)*1000 + tofpet_channel;
            tmp = boardMapsMu["MuFilter"][board.first][slots[tofpet_id]];
+           // mini DTs are labelled DS 5V, board is 32
+           if (tmp == "DS_5Vert") continue;
            if (debug || !(tmp.find("not") == string::npos))
            {
              LOG (info) << system << " " << key << " " << board.first << " " << tofpet_id
@@ -627,6 +629,8 @@ void ConvRawData::Process1()
            system = MufiSystem[board_id][tofpet_id];
            key = (tofpet_id%2)*1000 + tofpet_channel;
            tmp = boardMapsMu["MuFilter"][board_name][slots[tofpet_id]];
+           // mini DTs are labelled DS 5V, board is 32
+           if (tmp == "DS_5Vert") continue;
            if (debug || !(tmp.find("not") == string::npos))
            {
              LOG (info) << system << " " << key << " " << board_name << " " << tofpet_id


### PR DESCRIPTION
- skip the miniDT signals in the data conversion, separate task will be put in place for this purpose
- first line support for the 2025 filling scheme, another PR #299 treats further improvements 