### PR TITLE
NaN mass guards for MC track stack and track.GetMass

### DIFF
--- a/shipdata/ShipMCTrack.cxx
+++ b/shipdata/ShipMCTrack.cxx
@@ -139,8 +139,16 @@ Double_t ShipMCTrack::GetMass() const
     if ( particle ) { return particle->Mass(); }
     else { return 0.; }
    }
+  }else{
+   if (!std::isnan(fM)) { return fM; }
+   else{
+    if ( TDatabasePDG::Instance() ) {
+     TParticlePDG* particle = TDatabasePDG::Instance()->GetParticle(fPdgCode);
+     if ( particle && std::isnan(particle->Mass()) ) { return particle->Mass(); }
+     else { return 0.; }
+    }
+   }
   }
-  return fM;
 }
 // -------------------------------------------------------------------------
 

--- a/shipdata/ShipStack.cxx
+++ b/shipdata/ShipStack.cxx
@@ -438,6 +438,11 @@ void ShipStack::SelectTracks()
     thisPart->Momentum(p);
     Double_t energy = p.E();
     Double_t mass   = p.M();
+    if (std::isnan(mass)) mass == thisPart->GetMass();
+    if (std::isnan(mass)){
+       LOG(WARNING) << "ShipStack: NaN particle mass detected => setting to zero for "
+                    << thisPart->GetPdgCode();
+    }
 //    Double_t mass   = thisPart->GetMass();
     Double_t eKin = energy - mass;
 


### PR DESCRIPTION
Observed for neutrino MC
Added a fix for new MC in ShipStack and a workaround for existing samples(track.GetWeight)

<img width="1303" height="527" alt="image" src="https://github.com/user-attachments/assets/9436f806-9410-4222-bbca-8dbad2c3a791" />


